### PR TITLE
Assertion Standardization

### DIFF
--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -353,7 +353,7 @@ Short description of the badge achievement.
 
 <a name="badge-class-image"></a>
 * `image : <url>` __required__<br/>
-URL or DataURL of the image for the badge.<br/>
+URL or DataURL of the image for the badge. The linked image __must__ be a square PNG or SVG, with minimum dimensions of 90px and maximum file size of 256kb.<br/>
 _The Badge Class `image` is the generic image used to represent all awards of the badge, as opposed to a baked badge image with a particular Badge Assertion embedded into it - this may be included in a Badge Assertion [`image`](#assertion-image) field._
 
 <a name="badge-class-criteria"></a>
@@ -707,6 +707,8 @@ To assert structural validity, Displayers __should__ ensure the following badge 
 * `verify`: __must__ be an object
 	* `type`: __must__ be either "hosted" or "signed"
 	* `url`: __must__ be a ***URL***
+
+Displayers may __optionally__ verify that a badge award does not exceed any expiry date included in the Badge Assertion `expires` field.
 
 ## Validation
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -11,7 +11,7 @@ A hosted assertion is a file containing a well-formatted badge assertion in JSON
 
 ### Signed
 
-A signed badge is in the form of a [JSON Web Signature](http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html). Signed badges use the Backpack javascript [issuer API](https://github.com/mozilla/openbadges/wiki/Issuer-API) to pass a signature rather than a URL. The JSON representation of the badge assertion should be used as the JWS payload.
+A signed badge is in the form of a [JSON Web Signature](http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html). Signed badges use the Backpack javascript [issuer API](https://github.com/mozilla/openbadges/blob/development/docs/apis/issuer_api.md) to pass a signature rather than a URL. The JSON representation of the badge assertion should be used as the JWS payload.
 
 ## Assertion Specification
 
@@ -28,18 +28,18 @@ Fields marked **in bold letters** are mandatory.
 | **recipient** | [IdentityObject](#identityobject) | The recipient of the achievement. |
 | **badge** | URL | URL that describes the type of badge being awarded. The endpoint should be a [BadgeClass](#badgeclass) |
 | **verify** | [VerificationObject](#verificationobject) | Data to help a third party verify this assertion. |
-| **issuedOn** | [DateTime](#datetime) | Date that the achievement was awarded. |
+| **issuedOn** | [DateTime](#primitives) | Date that the achievement was awarded. |
 | image | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing this user's achievement. This must be a PNG image, and if possible, the image should be prepared via the [Baking specification](https://github.com/mozilla/openbadges-specification/blob/master/Badge-Baking/latest.md). |
 | evidence | URL | URL of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. |
-| expires | [DateTime](#datetime) | If the achievment has some notion of expiry, this indicates when a badge should no longer be considered valid. |
+| expires | [DateTime](#primitives) | If the achievment has some notion of expiry, this indicates when a badge should no longer be considered valid. |
 
 
 #### <a id="identity-object"></a>IdentityObject
 
 Property | Expected Type | Description
 --------|------------|-----------
-**identity** | [IdentityHash](#identityhash) or Text | Either the hash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information, it is strongly recommended that an IdentityHash be used.
-**type** | [IdentityType](#identitytype) | The type of identity.
+**identity** | [IdentityHash](#primitives) or Text | Either the hash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information, it is strongly recommended that an IdentityHash be used.
+**type** | [IdentityType](#primitives) | The type of identity.
 **hashed** | Boolean | Whether or not the `id` value is hashed.
 salt | Text | If the recipient is hashed, this should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
 
@@ -62,8 +62,17 @@ Property | Expected Type | Description
 **image** | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing the achievement.
 **criteria** | URL | URL of the criteria for earning the achievement. If the badge represents an educational achievement, consider marking up this up with [LRMI](http://www.lrmi.net/)
 **issuer** | URL | URL of the organization that issued the badge. Endpoint should be an [IssuerOrganization](#issuerorganization)
-alignment | Array of [AlignmentObject](#alignmentobject)s | List of objects describing which educational standards this badge aligns to, if any.
+alignment | Array of [AlignmentObjects](#alignmentobject) | List of objects describing which educational standards this badge aligns to, if any.
 tags | Array of Text | List of tags that describe the type of achievement.
+
+
+#### <a id="alignment-object"></a>AlignmentObject
+
+Property | Expected Type | Description
+--------|------------|-----------
+**name** | Text | Name of the alignment.
+**url** | URL | URL linking to the official description of the standard.
+description | Text | Short description of the standard
 
 
 #### <a id="issuer-organization"></a>IssuerOrganization
@@ -76,15 +85,6 @@ description | Text | A short description of the institution
 image | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | An image representing the institution
 email | Text | Contact address for someone at the organization.
 revocationList | URL |  URL of the Badge Revocation List. The endpoint should be a JSON representation of an object where the keys are the **uid** a revoked badge assertion, and the values are the reason for revocation. This is only necessary for signed badges.
-
-
-#### <a id="alignment-object"></a>AlignmentObject
-
-Property | Expected Type | Description
---------|------------|-----------
-**name** | Text | Name of the alignment.
-**url** | URL | URL linking to the official description of the standard.
-description | Text | Short description of the standard
 
 
 ### <a id="additional-properties"></a>Additional Properties
@@ -259,8 +259,8 @@ resource that returns a 200 OK.
   * `salt` (optional): must be **text**
 * `image` (optional): must be a valid **URL** or **Data URL**.
 * `evidence` (optional): must be a valid **URL**
-* `issuedOn` (optional): must be a valid [**DateTime**](#datetime)
-* `expires` (optional): must be a valid [**DateTime**](#datetime)
+* `issuedOn` (optional): must be a valid [**DateTime**](#primitives)
+* `expires` (optional): must be a valid [**DateTime**](#primitives)
 * `verify`: must be an object
   * `type`: must be either "hosted" or "signed"
   * `url`: must be a **URL**

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -2,12 +2,14 @@
 
 ## Status of This Document
 
+___To follow___
+
 <!--depends on track for ietf ie standards/ experimental etc http://tools.ietf.org/html/rfc2223#section-5
 alternative w3c example http://www.w3.org/TR/json-ld/ - overview of document history, participants etc-->
 
 ## Abstract
 
-The Open Badge Infrastructure (OBI) is a set of software tools and specifications for implementing Open Badge applications. The OBI provides a framework for creating, issuing and displaying Open Badges. The Open Badges Assertion Specification defines the structure of an awarded Open Badge. An Open Badges Assertion uses JSON-structured data to describe a specific badge issued to a specific earner. The Assertion content facilitates communicating and verifying the achievement that the badge represents.
+The Open Badge Infrastructure (OBI) is a set of software tools and specifications for implementing Open Badge applications. The OBI provides a framework for creating, issuing and displaying Open Badges. The Open Badges Assertion Specification defines the structure of an awarded Open Badge. An Open Badges Assertion uses JSON-structured data to describe a specific badge issued to a specific Earner. The Assertion content facilitates communicating and verifying the achievement that the badge represents.
 
 ## Table of Contents
 
@@ -43,11 +45,11 @@ The Open Badge Infrastructure Assertion specification aims to describe each awar
 This typically includes descriptive information about the achievement, an image and the date of issue. Additionally, an assertion should include the following information to aid client implementations:
 
 * criteria for earning the badge
-* verification details for the earner identity and badge award
+* verification details for the Earner identity and badge award
 
 The Assertion specification defines a series of required and optional properties to fulfill the above aims. Assertions may also include optional information such as evidence, educational standards alignment details and an expiry date.
 
-The purpose of the Assertion specification is to provide a reference for all implementers of Open Badge systems. This primarily means badge issuers and displayers.
+The purpose of the Assertion specification is to provide a reference for all implementers of Open Badge systems. This primarily means badge Issuers and Displayers.
 
 ___Proposals are currently under discussion regarding extending the Assertion structure and representing objects inline - see these threads:___
 
@@ -80,82 +82,82 @@ The Open Badges Assertion specification uses the following terms as defined:
 <a name="term-badge-assertion"><a>
 __Badge Assertion__
 
-A JSON-structured representation of a badge awarded to an earner. An Assertion describes the badge [earner](#term-earner), what the badge represents and the [issuer](#term-issuer). The data items within an Assertion include: a unique ID; the earner (recipient) identity; details of the [badge class](#term-badge-class) (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [hosted](#term-hosted-badge) or [signed](#term-signed-badge).
+A JSON-structured representation of a badge awarded to an Earner. An Assertion describes the badge [Earner](#term-earner), what the badge represents and the [Issuer](#term-issuer). The data items within an Assertion include: a unique ID; the Earner (recipient) identity; details of the [Badge Class](#term-badge-class) (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge).
 
 <a name="term-assessment"></a>
 __Assessment__
 
-In some badging systems, earner [evidence](#term-evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the Assertion.
+In some badging systems, Earner [evidence](#term-evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the Badge Assertion.
 
 <a name="term-award"></a>
 __Award__
 
-In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#term-issue) it - this involves the badge [issuer](#term-issuer) creating an Assertion to describe the award.
+In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#term-issue) it - this involves the badge [Issuer](#term-issuer) creating a Badge Assertion to describe the award.
 
 <a name="term-backpack"></a>
 __Backpack__
 
-A Backpack is a software tool through which [earners](#term-earner) can collect Open Badges they have been awarded. Typically a Backpack allows the earner to control visibility of their badges. [Displayers](#term-displayer) may connect to Backpacks to retrieve the data about badges associated with an earner.
+A Backpack is a software tool through which [Earners](#term-earner) can collect Open Badges they have been awarded. Typically a Backpack allows the Earner to control visibility of their badges. [Displayers](#term-displayer) may connect to Backpacks to retrieve the data about badges associated with an Earner.
 
 <a name="term-badge"></a>
 __Badge__
 
-In the context of the OBI, a badge is loosely described as a digital representation of a skill, learning achievement or experience. A badge is represented in digital contexts as an image and some metadata. For the badge to exist within the OBI, this metadata must conform to the Assertion specification.
+In the context of the OBI, a badge is loosely described as a digital representation of a skill, learning achievement or experience. A badge is represented in digital contexts as an image and some metadata. For the badge to exist within the OBI, this metadata __must__ conform to the Assertion specification.
 
 <a name="term-badge-class"></a>
 __Badge Class__
 
-The badge class forms part of an Open Badge Assertion. The badge class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A badge class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the badge Assertion for each award of the badge. The badge class file should include a link to the [issuer organization](#term-issuer-organization).
+The Badge Class forms part of an Open Badge Assertion. The Badge Class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A Badge Class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the Badge Assertion for each award of the badge. The Badge Class file __should__ include a link to the [Issuer Organization](#term-issuer-organization).
 
 <a name="term-bake"></a>
 __Bake, Baking, Baked Badge__
 
-A baked badge is a badge image file with the data for an Assertion embedded into it. The image may be a PNG or SVG file. Baking badges makes them more portable, allowing earners to communicate and display them wherever they choose. Software can extract the Assertion from a baked badge to provide access to the metadata describing the award.
+A baked badge is a badge image file with the data for an Assertion embedded into it. The image __may__ be a PNG or SVG file. Baking badges makes them more portable, allowing Earners to communicate and display them wherever they choose. Software can extract the Assertion from a baked badge to provide access to the metadata describing the award.
 
 <a name="term-criteria"></a>
 __Criteria__
 
-A definition of the requirements for earning a badge. The criteria for a badge are included in the [badge class](#term-badge-class) as a URL.
+A definition of the requirements for earning a badge. The criteria for a badge are included in the [Badge Class](#term-badge-class) as a URL.
 
 <a name="term-displayer"></a>
 __Displayer__
 
-A badge displayer presents information about public badge awards in a digital context. Badge earners can add their awarded badges to public collections, which displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge displayers should [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the earner claiming it.
+A badge Displayer presents information about public badge awards in a digital context. Badge Earners can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
 
 <a name="term-earner"></a>
 __Earner__
 
-An earner is someone who has been awarded one or more Open Badges. Depending on the badging system, the earner may apply for a badge, supplying supporting evidence. When an issuer awards a badge, they build information about the earner identity into a new badge Assertion.
+An Earner is someone who has been awarded one or more Open Badges. Depending on the badging system, the Earner may apply for a badge, supplying supporting evidence. When an Issuer awards a badge, they build information about the Earner identity into a new Badge Assertion.
 
 <a name="term-evidence"></a>
 __Evidence__
 
-A badge Assertion may include a URL representing evidence for the badge award. Depending on the badging system, the earner may have submitted this evidence as part of an application process. Typically, the issuer would compared the evidence to the badge [criteria](#term-criteria) in order to make an awarding decision.
+A Badge Assertion __may__ include a URL representing evidence for the badge award. Depending on the badging system, the Earner may have submitted this evidence as part of an application process. Typically, the Issuer would compared the evidence to the badge [criteria](#term-criteria) in order to make an awarding decision.
 
 <a name="term-hosted-badge"></a>
 __Hosted Badge__
 
-A hosted badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a hosted badge are: the [assertion](#term-badge-assertion); the [badge class](#term-badge-class); the [issuer organization](#term-issuer-organization). The badge Assertion includes a [verification](#term-verify) field in which either a hosted or [signed](#term-signed-badge) type is specified.
+A ___hosted___ badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a ___hosted___ badge are: the [Badge Assertion](#term-badge-assertion); the [Badge Class](#term-badge-class); the [Issuer Organization](#term-issuer-organization). The Badge Assertion includes a [verification](#term-verify) field in which either a ___hosted___ or [___signed___](#term-signed-badge) type is specified.
 
 <a name="term-issue"></a>
 __Issue__
 
-Issuing is the act of awarding a badge to an earner. Typically badge [issuers](#term-issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an issuer must create a [Badge Assertion](#term-badge-assertion), which may be [hosted](#term-hosted-badge) or [signed](#term-signed-badge).
+Issuing is the act of awarding a badge to an Earner. Typically badge [Issuers](#term-issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an Issuer __must__ create a [Badge Assertion](#term-badge-assertion), which __may__ be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge).
 
 <a name="term-issuer"></a>
 __Issuer__
 
-An issuer is a person or organization (or department within an organization) who/ which awards Open Badges to earners. Typically the issuer is responsible for designing and creating the badge as well as awarding it. The issuer may choose to implement various optional processes in a badging system, such as [assessment](#term-assessment).
+An Issuer is a person or organization (or department within an organization) who/ which awards Open Badges to Earners. Typically the Issuer is responsible for designing and creating the badge as well as awarding it. The Issuer may choose to implement various optional processes in a badging system, such as [assessment](#term-assessment).
 
 <a name="term-issuer-organization"></a>
 __Issuer Organization__
 
-The issuer organization is the part of an Open Badge Assertion in which the badge issuer is described. The issuer organization must be included in the [badge class](#term-badge-class) by URL. The URL must return a JSON representation of the issuer, in which fields specify the issuer name and URL, as well as other optional descriptive properties. Typically the issuer organization data will be used to [verify](#term-verify) awarded badges.
+The Issuer Organization is the part of an Open Badge Assertion in which the badge Issuer is described. The Issuer Organization __must__ be included in the [Badge Class](#term-badge-class) by URL. The URL __must__ return a JSON representation of the Issuer, in which fields specify the Issuer name and URL, as well as other optional descriptive properties. Typically the Issuer Organization data will be used to [verify](#term-verify) awarded badges.
 
 <a name="term-metadata"></a>
 __Metadata__
 
-In the OBI, metadata is information about badges, badge awards and badge issuers. OBI metadata is defined in JSON as part of the Assertion specification.
+In the OBI, metadata is information about badges, badge awards and badge Issuers. OBI metadata is defined in JSON as part of the Assertion specification.
 
 <a name="term-obi"></a>
 __Open Badge Infrastructure (OBI)__
@@ -165,22 +167,22 @@ The OBI is a set of software tools and specifications to support Open Badge syst
 <a name="term-revoke"></a>
 __Revoke__
 
-Badge issuers can revoke badges they awarded to earners. In such cases, the [issuer organization](#term-issuer-organization) should include a list of signed badges that have been revoked, and/or provide a revocation response to requests at the original badge assertion URL. Badge displayers should not display revoked badges and should check revocation status during [verification](#term-verify).
+Badge Issuers can revoke badges they awarded to Earners. In such cases, the [Issuer Organization](#term-issuer-organization) __should__ include a list of ___signed___ badges that have been revoked, and/or provide a revocation response to requests at the original Badge Assertion URL. Badge Displayers __should not__ display revoked badges and should check revocation status during [verification](#term-verify).
 
 <a name="term-signed-badge"></a>
 __Signed Badge__
 
-A signed badge has its Assertion data included in a JSON Web Signature (JWS). Typically a signed badge still uses hosted JSON files for the [badge class](#term-badge-class) and [issuer organization](#term-issuer-organization), but the [badge assertion](#term-badge-assertion) JSON is itself packaged as a signature. The badge Assertion includes a [verification](#term-verify) field in which either a hosted or [signed](#term-signed-badge) type is specified.
+A ___signed___ badge has its Assertion data included in a JSON Web Signature (JWS). Typically a ___signed___ badge still uses hosted JSON files for the [Badge Class](#term-badge-class) and [Issuer Organization](#term-issuer-organization), but the [Badge Assertion](#term-badge-assertion) JSON is itself packaged as a signature. The Badge Assertion includes a [verification](#term-verify) field in which either a ___hosted___ or [___signed___](#term-signed-badge) type is specified.
 
 <a name="term-validate"></a>
 __Validate, Validation, Validator__
 
-Validation is the act of checking a badge assertion for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any resources linked within the assertion are available.
+Validation is the act of checking a Badge Assertion for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any resources linked within the assertion are available.
 
 <a name="term-verify"></a>
 __Verify, Verification__
 
-Verification is the act of checking that a badge was awarded by the issuer to the earner. Badge displayers should carry out verification on badges before displaying them. Badge issuers should include the information necessary for this verification to be implemented. Verification must be tailored to whether a badge assertion is [signed](#term-signed-badge) or [hosted](#term-hosted-badge).
+Verification is the act of checking that a badge was awarded by the Issuer to the Earner. Badge Displayers __should__ carry out verification on badges before displaying them. Badge Issuers __should__ include the information necessary for this verification to be implemented. Verification should be tailored to whether a Badge Assertion is [___signed___](#term-signed-badge) or [___hosted___](#term-hosted-badge).
 
 <!-- 
 * _internet terms http://tools.ietf.org/html/rfc1983_
@@ -192,15 +194,15 @@ Verification is the act of checking that a badge was awarded by the issuer to th
 
 Adopting the OBI involves understanding a range of concepts which refer to existing and well-known real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
 
-An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to earners. The generic badge is defined using a __Badge Class__, while an awarded badge is defined using a __Badge Assertion__. In this sense, a generic badge can be conceptualized as the template for awarded badges. This connection is implementated by including a link to a __Badge Class__ in each __Badge Assertion__.
+An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to Earners. The generic badge is defined using a __Badge Class__, while an awarded badge is defined using a __Badge Assertion__. In this sense, a generic badge can be conceptualized as the template for awarded badges. This connection is implemented by including a link to a __Badge Class__ in each __Badge Assertion__.
 
 People who are awarded Open Badges are referred to as __Earners__. __Earners__ may be awarded badges directly, or through assessment processes involving submission of evidence - the nature of the issuing process is determined by the Issuer.
 
 The people and organizations who award Open Badges are referred to as __Issuers__. Issuing is the technical act of awarding a badge, the implementation of which is creating a __Badge Assertion__.
 
-__Displayers__ of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. __Displayers__ therefore deal with the data in __Badge Assertions__, which is created by __Issuers__. Prior to display, Open Badges can be collected using software tools - some of these referred to as __Backpacks__. __Displayers__ may retrieve the data describing an __Earner's__ badges from a __Backpack__. The __Earner__ should have full control over which badges are publicly visible.
+__Displayers__ of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. __Displayers__ therefore deal with the data in __Badge Assertions__, which is created by __Issuers__. Prior to display, Open Badges can be collected using software tools - some of these referred to as __Backpacks__. __Displayers__ may retrieve the data describing an __Earner's__ badges from a __Backpack__. The __Earner__ __should__ have full control over which badges are publicly visible.
 
-For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. __Issuers__ should include the information necessary for this verification, while __Displayers__ should use it to check that a badge was awarded by an __Issuer__, to an __Earner__. 
+For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. __Issuers__ __should__ include the information necessary for this verification, while __Displayers__ __should__ use it to check that a badge was awarded by an __Issuer__, to an __Earner__. 
 
 ## Data Model
 
@@ -245,7 +247,7 @@ The data types and purpose of these properties are as follows.
 
 <a name="assertion-uid"></a>
 * `uid : <text>` __required__<br/>
-Unique Identifier for the badge assertion. This should be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
+Unique Identifier for the badge assertion. This __should__ be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
 
 <a name="assertion-recipient"></a>
 * `recipient : `[`IdentityObject`](#identity-object) __required__<br/>
@@ -265,7 +267,7 @@ Either an ISO 8601 date or a standard 10-digit Unix timestamp indicating the dat
 
 <a name="assertion-image"></a>
 * `image : <url>` _optional_<br/>
-URL or DataURL for the badge image. This must be a PNG or SVG image, and should have the assertion data baked into it.<br/>
+URL or DataURL for the badge image. This __must__ be a PNG or SVG image, and __should__ have the assertion data baked into it.<br/>
 _The Badge Assertion image is distinct from the Badge Class image, which is the same for all awards of a badge - the Badge Assertion image may be baked in which case it is unique to the Badge Assertion._
 
 <a name="assertion-evidence"></a>
@@ -275,7 +277,7 @@ _May be a page linking out to other pages if linking directly to the evidence is
 
 <a name="assertion-expires"></a>
 * `expires : <DateTime>` _optional_<br/>
-A date from which the achievement represented by the badge should be considered invalid.
+A date from which the achievement represented by the badge __should__ be considered invalid.
 
 ##### Identity Object
 
@@ -295,7 +297,7 @@ The purpose and data type for each of these properties follow.
 
 <a name="identity-object-identity"></a>
 * `identity : <text>` __required__<br/>
-Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, a hash should be used. The hash string should be preceded by the algorithm used to generate the hash (e.g. `sha256`) and a dollar sign (`$`).
+Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, a hash __should__ be used. The hash string __should__ be preceded by the algorithm used to generate the hash (e.g. `sha256`) and a dollar sign (`$`).
 
 <a name="identity-object-type"></a>
 * `type : <text>` __required__<br/>
@@ -307,7 +309,7 @@ Boolean indicator of whether or not the [`identity`](#identity-object-identity) 
 
 <a name="identity-object-salt"></a>
 * `salt : <text>` _optional_<br/>
-Hashed [`identity`](#identity-object-identity) values may be salted. If the recipient is [hashed](#identity-object-hashed), `salt` should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
+Hashed [`identity`](#identity-object-identity) values __may__ be salted. If the recipient is [hashed](#identity-object-hashed), `salt` __should__ contain the string used to salt the hash. If this value is not provided, it __should__ be assumed that the hash was not salted.
 
 ##### Verification Object
 
@@ -450,7 +452,7 @@ Contact email address for somone at the organization.
 <a name="issuer-organization-revocationlist"></a>
 * `revocationList : <url>` _optional_<br/>
 URL for list of revoked badges - _only for signed badges_.<br/>
-_The revocationList endpoint should be a JSON representation of an object where the keys are the uids for revoked badge assertions and the values are the reason for revocation._
+_The revocationList endpoint should be a JSON representation of an object where the keys are the uids for revoked assertions and the values are the reason for revocation._
 
 ### Summary Tables
 
@@ -544,7 +546,7 @@ __Issuer Organization__
 
 The three main elements of a badge are: Badge Assertion; Badge Class; Issuer Organization.
 
-The [Badge Assertion](#badge-assertion) may be represented within a hosted JSON file or a JSON Web Signature (JWS). A Badge Assertion describes a badge awarded to an earner:
+The [Badge Assertion](#badge-assertion) __may__ be represented within a hosted JSON file or a JSON Web Signature (JWS). A Badge Assertion describes a badge awarded to an Earner:
 
 ```json
 {
@@ -566,7 +568,7 @@ The [Badge Assertion](#badge-assertion) may be represented within a hosted JSON 
 }
 ```
 
-The Badge Assertion links to a [Badge Class](#badge-class) in its `badge` field. This should be a hosted JSON file describing the badge awarded:
+The Badge Assertion links to a [Badge Class](#badge-class) in its `badge` field. This __must__ be a hosted JSON file describing the badge awarded:
 
 ```json
 {
@@ -603,7 +605,7 @@ The Badge Class includes a link to the [Issuer Organization](#issuer-organizatio
 }
 ```
 
-Issuers using signed badges __may__ define a revocation list JSON file in which previously awarded badges can be revoked (included in the `revocationList` field in the Issuer Organization):
+Issuers using ___signed___ badges __may__ define a revocation list JSON file in which previously awarded badges can be revoked (included in the `revocationList` field in the Issuer Organization):
 
 ```json
 {
@@ -615,26 +617,26 @@ Issuers using signed badges __may__ define a revocation list JSON file in which 
 
 ## Assertion Types
 
-There are two types of Open Badge: Hosted and Signed. In both cases, the assertion involves three sets of JSON: the Badge Assertion; the Badge Class; the Issuer Organization. The difference between hosted and signed badges relates specifically to the Badge Assertion.
+There are two types of Open Badge: ___hosted___ and ___signed___. In both cases, the assertion involves three sets of JSON: the Badge Assertion; the Badge Class; the Issuer Organization. The difference between ___hosted___ and ___signed___ badges relates specifically to the Badge Assertion.
 
-In a hosted badge, the Badge Assertion, Badge Class and Issuer Organization are all stored in hosted files, with the three files linked as follows:
+In a ___hosted___ badge, the Badge Assertion, Badge Class and Issuer Organization are all stored in hosted files, with the three files linked as follows:
 
 * Badge Assertion `badge` field includes the URL of the Badge Class
 * Badge Class `issuer` field includes the URL of the Issuer Organization
 
-In a signed badge, these links remain the same, but the Badge Assertion is not stored in a hosted JSON file - it is packaged in a JSON Web Signature (JWS). This may be prepared programmatically within the Issuer system whenever a badge is awarded to an Earner.
+In a ___signed___ badge, these links remain the same, but the Badge Assertion is not stored in a hosted JSON file - it is packaged in a JSON Web Signature (JWS). This may be prepared programmatically within the Issuer system whenever a badge is awarded to an Earner.
 
-The Badge Assertion `verify` `type` field should indicate whether a badge is signed or hosted.
+The Badge Assertion `verify` `type` field __must__ indicate whether a badge is ___signed___ or ___hosted___.
 
 ### Signed Open Badge Structure
 
-The structure of the JWS comprising a signed Open Badge is as follows:
+The structure of the JWS comprising a ___signed___ Open Badge is as follows:
 
 ```
 <encoded JWS header>.<encoded JWS payload>.<encoded JWS signature>
 ```
 
-The JSON representation of the badge assertion should be used as the JWS payload. An RSA-SHA256 algorithm should be used for signing.
+The JSON representation of the Badge Assertion __must__ be used as the JWS payload. An RSA-SHA256 algorithm __should__ be used for signing.
 
 Example (line breaks for display purposes):
 
@@ -646,13 +648,13 @@ eyJ1aWQiOiJhYmMtMTIzNCIsInJlY2lwaWVudCI6eyJ0eXBlIjoiZW1haWwiLCJoYXNoZWQiOnRydWUs
 Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg
 ```
 
-The URL of the public key corresponding to the private key used for signing should be included in the Badge Assertion `verify` `url` field. This allows badge Displayers to verify that a signed badge is legitimate.
+The URL of the public key corresponding to the private key used for signing __must__ be included in the Badge Assertion `verify` `url` field. This allows badge Displayers to verify that a ___signed___ badge is legitimate.
 
 ## Additional Properties
 
-Additional properties may be included in Open Badges providing they don't clash with the specified properties. **Processors should preserve all properties when rehosting or retransmitting**.
+Additional properties __may__ be included in Open Badges providing they don't clash with the specified properties. **Processors should preserve all properties when rehosting or retransmitting**.
 
-Any additional properties __should__ be namespaced to avoid clashing with future properties. For example, if the issuer at **example.org** wants to add a `foo` property to the assertion, the property name should be `example.org:foo`. This will help prevent unforseen errors should an `foo` property be defined in a later version of the specification.
+Any additional properties __should__ be namespaced to avoid clashing with future properties. For example, if the issuer at **example.org** wants to add a `foo` property to the assertion, the property name __should__ be `example.org:foo`. This will help prevent unforseen errors should a `foo` property be defined in a later version of the specification.
 
 Discussions regarding extensions to the Open Badge structures can be found here: https://github.com/mozilla/openbadges-discussion/issues/20
 
@@ -660,15 +662,15 @@ Discussions regarding extensions to the Open Badge structures can be found here:
 
 Typically a badge Issuer is responsible for creating the three parts of an Open Badge, as well as deciding who to award badges to. The Issuer __may__ use a single Issuer Organization file for all of the badges they issue. Each Issuer Organization may be included in the `issuer` field for multiple Badge Classes. In turn, each Badge Class may be included in the `badge` field for multiple Badge Assertions.
 
-The Issuer __must__ host JSON resources at publicly accessible stable locations, with the content-type set to `application/json`. Any resources linked from the Open Badge JSON files should also be at stable URLs.
+The Issuer __must__ host JSON resources at publicly accessible stable locations, with the content-type set to `application/json`. Any resources linked from the Open Badge JSON files __should__ also be at stable URLs.
 
-Where signed badges are used, the Issuer must also host the public key corresponding to the private key they use for signing at a stable URL. 
+Where ___signed___ badges are used, the Issuer __must__ also host the public key corresponding to the private key they use for signing at a stable URL. 
 
 ### Badge Revocation
 
-To revoke hosted badges, Issuers __should__ respond to requests on the revoked Badge Assertions with an HTTP Status of `410 Gone` and a body of `{ "revoked":true }`.
+To revoke ___hosted___ badges, Issuers __should__ respond to requests on the revoked Badge Assertions with an HTTP Status of `410 Gone` and a body of `{ "revoked":true }`.
 
-To revoke signed badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with the Badge Assertion `uid`s as keys adn the reason for revocation as values. The revocation list JSON URL should be included in the Issuer Organization `revocatonList` field.
+To revoke ___signed___ badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with the Badge Assertion `uid`s as keys and the reason for revocation as values. The revocation list JSON URL __should__ be included in the Issuer Organization `revocatonList` field.
 
 <!--setting content type examples move to sep doc?-->
 
@@ -676,13 +678,13 @@ To revoke signed badges, the Issuer __should__ host a revocation list JSON file 
 
 Open Badge Displayers __should__ carry out verification steps prior to presenting awarded badges for output in digital contexts.
 
-To verify a hosted badge, Displayers should:
+To verify a ___hosted___ badge, Displayers __should__:
 
-1. Perform an HTTP GET request on the `verify.url` from the Badge Assertion. If the HTTP Status is not eventually 200 OK, assertion MUST BE treated as invalid.
+1. Perform an HTTP GET request on the `verify.url` from the Badge Assertion. If the HTTP Status is not eventually 200 OK, assertion __must__ treated as invalid.
 
 2. [Assert structural validity](#assert-structural-validity).
 
-To verify a signed badge, Displayers should:
+To verify a ___signed___ badge, Displayers __should__:
 
 1. Unpack the JWS payload. This will be a JSON string representation of the Badge Assertion.
 
@@ -694,14 +696,14 @@ To verify a signed badge, Displayers should:
 
 5. Perform an HTTP GET request on `verify.url` and store public key. If the HTTP status is not 200 OK (either directly or through 3xx redirects), the badge __must__ be treated as invalid.
 
-6. With the public key, perform a JWS verification on the JWS object. If the verification fails, the badge MUST be treated as invalid.
+6. With the public key, perform a JWS verification on the JWS object. If the verification fails, the badge __must__ be treated as invalid.
 
 7. Retrieve the revocation list from the Issuer Organization URL and ensure the `uid` of the badge does not appear in the list.
 
 8. If the above steps pass, assertion __may__ be treated as valid.
 
 <a name="assert-structural-validity"></a>
-To assert structural validity, Displayers should ensure the following badge properties:
+To assert structural validity, Displayers __should__ ensure the following badge properties:
 
 * `badge`: __must__ be a valid **URL**. An HTTP GET request __must__ be performed on the URL to ensure eventual 200 OK status.
 * `recipient`: __must__ be an object
@@ -715,7 +717,7 @@ To assert structural validity, Displayers should ensure the following badge prop
 * `expires` (_optional_): __must__ be a valid ***DateTime***
 * `verify`: __must__ be an object
 	* `type`: __must__ be either "hosted" or "signed"
-	* `url`: must be a ***URL***
+	* `url`: __must__ be a ***URL***
 
 ## Validation
 
@@ -731,6 +733,10 @@ https://github.com/mozilla/openbadges-validator/
 
 ## History
 
+___To follow___
+
 <!--explain working groups etc, in particular explain contentious decisions, "why" as well as "how"-->
 
 ## References
+
+___To follow___

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -2,14 +2,39 @@
 
 ## Status of This Document
 
-* _depends on track for ietf ie standards/ experimental etc http://tools.ietf.org/html/rfc2223#section-5_
-* _alternative w3c example http://www.w3.org/TR/json-ld/ - overview of document history, participants etc_
+<!--depends on track for ietf ie standards/ experimental etc http://tools.ietf.org/html/rfc2223#section-5
+alternative w3c example http://www.w3.org/TR/json-ld/ - overview of document history, participants etc-->
 
 ## Abstract
+
+The Open Badge Infrastructure (OBI) is a set of software tools and specifications for implementing Open Badge applications. The OBI provides a framework for creating, issuing and displaying Open Badges. The Open Badges Assertion Specification defines the structure of an awarded Open Badge. An Open Badges Assertion uses JSON-structured data to describe a specific badge issued to a specific earner. The Assertion content facilitates communicating and verifying the achievement that the badge represents.
 
 ## Table of Contents
 
 ## Introduction
+
+The Open Badge Infrastructure Assertion specification aims to describe each awarded badge in a way that is open, meaningful and verifiable. An Open Badge Assertion should include all of the information required to understand the award. Each assertion should define these core aspects of a badge award:
+
+* who earned the badge
+* what the badge represents
+* who issued the badge
+
+This typically includes descriptive information about the achievement, an image and the date of issue. Additionally, an assertion should include the following information to aid client implementations:
+
+* criteria for earning the badge
+* verification details for the earner identity and badge award
+
+The Assertion specification defines a series of required and optional data fields to fulfill the above aims. Assertions may also include optional information such as evidence, educational standards alignment details and an expiry date.
+
+The purpose of the Assertion specification is to provide a reference for all implementers of Open Badge systems. This primarily means badge issuers and displayers.
+
+___Proposals are currently under discussion regarding extending the Assertion structure and representing objects inline - see these threads:___
+
+* https://github.com/mozilla/openbadges-discussion/issues/20
+* https://github.com/mozilla/openbadges-specification/issues/5
+
+<!--explain motivation, applicability - this specification is intended to provide... to be used by... explain what obi spec is http://tools.ietf.org/html/rfc2223#section-7
+purpose, intended function, how it fits into context-->
 
 ## Conventions Used in This Document
 
@@ -17,7 +42,105 @@
 
 ## Intended Audience
 
+This document is intended for the following audiences:
+
+* implementers of badge issuing applications
+* implementers of badge displaying applications
+* individuals and organizations involved in the Open Badge ecosystem
+
+The primary audience is expected to be software developers, however the specification may also be relevant to designers, administrators and managers associated with Open Badge systems.
+
+The Open Badges Assertion specification relies on JSON syntax, some knowledge of which is required - see [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt) and [JSON.org](http://www.json.org/).
+
 ## Terminology
+
+The Open Badges Assertion specification uses the following terms as defined:
+
+### Assertion
+
+A JSON-structured representation of a badge awarded to an earner. An Assertion describes the badge [earner](#earner), what the badge represents and the [issuer](#issuer). The data items within an Assertion include: a unique ID; the earner (recipient) identity; details of the [badge class](#badge-class) (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [hosted](#hosted-badge) or [signed](#signed-badge).
+
+### Assessment
+
+In some badging systems, earner [evidence](#evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the Assertion.
+
+### Award
+
+In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#issue) it - this involves the badge [issuer](#issuer) creating an Assertion to describe the award.
+
+### Badge
+
+In the context of the OBI, a badge is loosely described as a digital representation of a skill, learning achievement or experience. A badge is represented in digital contexts as an image and some metadata. For the badge to exist within the OBI, this metadata must conform to the Assertion specification.
+
+### Badge Class
+
+The badge class forms part of an Open Badge Assertion. The badge class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A badge class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the badge Assertion for each award of the badge. The badge class file should include a link to the [issuer organization](#issuer-organization).
+
+### Bake, Baking, Baked Badge
+
+A baked badge is a badge image file with the data for an Assertion embedded into it. The image may be a PNG or SVG file. Baking badges makes them more portable, allowing earners to communicate and display them wherever they choose. Software can extract the Assertion from a baked badge to provide access to the metadata describing the award.
+
+### Criteria
+
+A definition of the requirements for earning a badge. The criteria for a badge are included in the [badge class](#badge-class) as a URL.
+
+### Displayer
+
+A badge displayer presents information about public badge awards in a digital context. Badge earners can add their awarded badges to public collections, which displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge displayers should [verify](#verify-verification) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the earner claiming it.
+
+### Earner
+
+An earner is someone who has been awarded one or more Open Badges. Depending on the badging system, the earner may apply for a badge, supplying supporting evidence. When an issuer awards a badge, they build information about the earner identity into a new badge Assertion.
+
+### Evidence
+
+A badge Assertion may include a URL representing evidence for the badge award. Depending on the badging system, the earner may have submitted this evidence as part of an application process. Typically, the issuer would compared the evidence to the badge [criteria](#criteria) in order to make an awarding decision.
+
+### Hosted Badge
+
+A hosted badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a hosted badge are: the [assertion](#assertion); the [badge class](#badge-class); the [issuer organization](#issuer-organization). The badge Assertion includes a [verification](#verify-verification) field in which either a hosted or [signed](#signed-badge) type is specified.
+
+### Issue
+
+Issuing is the act of awarding a badge to an earner. Typically badge [issuers](#issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an issuer must create a badge [Assertion](#assertion), which may be [hosted](#hosted-badge) or [signed](#signed-badge).
+
+### Issuer
+
+An issuer is a person or organization (or department within an organization) who/ which awards Open Badges to earners. Typically the issuer is responsible for designing and creating the badge as well as awarding it. The issuer may choose to implement various optional processes in a badging system, such as [assessment](#assessment).
+
+### Issuer Organization
+
+The issuer organization is the part of an Open Badge Assertion in which the badge issuer is described. The issuer organization must be included in the [badge class](#badge-class) by URL. The URL must return a JSON representation of the issuer, in which fields specify the issuer name and URL, as well as other optional descriptive fields. Typically the issuer organization data will be used to [verify](#verify-verification) awarded badges.
+
+### Metadata
+
+In the OBI, metadata is information about badges, badge awards and badge issuers. OBI metadata is defined in JSON as part of the Assertion specification.
+
+### Open Badge Infrastructure (OBI)
+
+The OBI is a set of software tools and specifications to support Open Badge systems. These tools provide a framework for issuing, displaying and earning Open Badges within an open ecosystem.
+
+### Revoke
+
+Badge issuers can revoke badges they awarded to earners. In such cases, the [issuer organization](#issuer-organization) should include a list of signed badges that have been revoked, and/or provide a revocation response to requests at the original badge assertion URL. Badge displayers should not display revoked badges and should check revocation status during [verification](#verify-verification).
+
+### Signed Badge
+
+A signed badge has its Assertion data included in a JSON Web Signature (JWS). Typically a signed badge still uses hosted JSON files for the [badge class](#badge-class) and [issuer organization](#issuer-organization), but the [assertion](#assertion) JSON is itself packaged as a signature. The badge Assertion includes a [verification](#verify-verification) field in which either a hosted or [signed](#signed-badge) type is specified.
+
+### Validate, Validation, Validator
+
+Validation is the act of checking a badge assertion for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any resources linked within the assertion are available.
+
+### Verify, Verification
+
+Verification is the act of checking that a badge was awarded by the issuer to the earner. Badge displayers should carry out verification on badges before displaying them. Badge issuers should include the information necessary for this verification to be implemented. Verification must be tailored to whether a badge assertion is [signed](#signed-badge) or [hosted](#hosted-badge).
+
+<!-- 
+* _internet terms http://tools.ietf.org/html/rfc1983_
+* _concise sections and more detailed sections http://tools.ietf.org/html/rfc2360#section-2.4_
+* _concise sections could be badge assertion, badge class etc (brief but with some description), summary tables (v concise), then more detail in implementation sections - primitive types?_
+-->
 
 ## Concepts
 
@@ -31,21 +154,29 @@
 
 #### Summary Tables
 
-(see http://tools.ietf.org/html/rfc2360#section-3.2)
+<!--see http://tools.ietf.org/html/rfc2360#section-3.2 for status codes etc-->
 
 #### Examples
 
+## Assertion Types
+
+<!--hosted and signed-->
+
+## Additional Properties
+
 ## Issuer Implementations
 
-(considerations)
+<!--considerations, includes revocation, setting content type-->
 
 ## Displayer Implementations
 
-(considerations)
+<!--considerations, includes verification-->
+
+## Validation
 
 ## History
 
-(explanation of decisions)
+<!--explain working groups etc, in particular explain contentious decisions, "why" as well as "how"-->
 
 ## References
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -171,23 +171,23 @@ Verification is the act of checking that a badge was awarded by the issuer to th
 
 Adopting the OBI involves understanding a range of concepts which refer to existing and well-known real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
 
-An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to earners. The generic badge is defined using a Badge Class, while an awarded badge is defined using a Badge Assertion. In this sense, a generic badge can be conceptualized as the template for awarded badges. This connection is implementated by including a link to a Badge Class in each Badge Assertion.
+An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to earners. The generic badge is defined using a __Badge Class__, while an awarded badge is defined using a __Badge Assertion__. In this sense, a generic badge can be conceptualized as the template for awarded badges. This connection is implementated by including a link to a __Badge Class__ in each __Badge Assertion__.
 
-People who are awarded Open Badges are referred to as Earners. Earners may be awarded badges directly, or through assessment processes involving submission of evidence - the nature of the issuing process is determined by the Issuer.
+People who are awarded Open Badges are referred to as __Earners__. __Earners__ may be awarded badges directly, or through assessment processes involving submission of evidence - the nature of the issuing process is determined by the Issuer.
 
-The people and organizations who award Open Badges are referred to as Issuers. Issuing is the technical act of awarding a badge, the implementation of which is creating a Badge Assertion.
+The people and organizations who award Open Badges are referred to as __Issuers__. Issuing is the technical act of awarding a badge, the implementation of which is creating a __Badge Assertion__.
 
-Displayers of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. Displayers therefore deal with the data in Badge Assertions, which is created by Issuers. Prior to display, Open Badges can be collected using software tools - some of these referred to as Backpacks. Displayers may retrieve the data describing an Earner's badges from a Backpack. The Earner should have full control over which badges are publicly visible.
+__Displayers__ of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. __Displayers__ therefore deal with the data in __Badge Assertions__, which is created by __Issuers__. Prior to display, Open Badges can be collected using software tools - some of these referred to as __Backpacks__. __Displayers__ may retrieve the data describing an __Earner's__ badges from a __Backpack__. The __Earner__ should have full control over which badges are publicly visible.
 
-For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. Issuers should include the information necessary for this verification, while Displayers should use it to check that a badge was awarded by an Issuer, to an Earner. 
+For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. __Issuers__ should include the information necessary for this verification, while __Displayers__ should use it to check that a badge was awarded by an __Issuer__, to an __Earner__. 
 
 ## Data Model
 
 Open Badges define their structures in JSON. Three JSON files make up an awarded badge: 
 
-* Badge Assertion
-* Badge Class
-* Issuer Organization
+* [Badge Assertion](#badge-assertion)
+* [Badge Class](#badge-class)
+* [Issuer Organization](#issuer-organization)
 
 These three include JSON objects, arrays and values. The Badge Assertion includes a field for the URL of the Badge Class, while the Badge Class includes a link to the Issuer Organization.
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -68,6 +68,10 @@ In some badging systems, earner [evidence](#evidence) is assessed as part of the
 
 In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#issue) it - this involves the badge [issuer](#issuer) creating an Assertion to describe the award.
 
+### Backpack
+
+A Backpack is a software tool through which [earners](#earner) can collect Open Badges they have been awarded. Typically a Backpack allows the earner to control visibility of their badges. [Displayers](#displayer) may connect to Backpacks to retrieve the data about badges associated with an earner.
+
 ### Badge
 
 In the context of the OBI, a badge is loosely described as a digital representation of a skill, learning achievement or experience. A badge is represented in digital contexts as an image and some metadata. For the badge to exist within the OBI, this metadata must conform to the Assertion specification.
@@ -143,6 +147,18 @@ Verification is the act of checking that a badge was awarded by the issuer to th
 -->
 
 ## Concepts
+
+Adopting the OBI involves understanding a range of concepts which refer to real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
+
+An Open Badge is a digital representation of a skill or achievement, which is communicated using JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to earners. The generic badge is defined using a Badge Class, while an awarded badge is defined using a Badge Assertion. In this sense, the generic badge can be conceptualized as the template for the awarded badges. This connection is present in the implementation of an awarded badge by including a link to the Badge Class in the Badge Assertion.
+
+People who are awarded Open Badges are referred to as Earners. Earners may be awarded badges directly, or through assessment processes involving submission of evidence - the nature of the issuing process is determined by the Issuer.
+
+The people and organizations who award Open Badges are referred to as Issuers. Issuing is the technical act of awarding a badge, the implementation of which is creating a Badge Assertion.
+
+Displayers of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. Displayers therefore deal with the data in Badge Assertions, which is created by Issuers. Prior to display, Open Badges can be collected using software tools - these may be referred to as Backpacks. Displayers may retrieve the data describing an earner's badges from a Backpack. The earner should have full control over which badges are publicly visible.
+
+For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. Issuers should include the information necessary for this verification, while Displayers should use it to check that a badge was awarded by an Issuer, to an Earner. 
 
 ## Data Model
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -29,7 +29,7 @@ Fields marked **in bold letters** are mandatory.
 | **badge** | URL | URL that describes the type of badge being awarded. The endpoint should be a [BadgeClass](#badgeclass) |
 | **verify** | [VerificationObject](#verificationobject) | Data to help a third party verify this assertion. |
 | **issuedOn** | [DateTime](#datetime) | Date that the achievement was awarded. |
-| image | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing this user's achievement. This must be a PNG image, and if possible, the image should be prepared via the [Baking specification](https://github.com/mozilla/openbadges/wiki/Badge-Baking). |
+| image | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing this user's achievement. This must be a PNG image, and if possible, the image should be prepared via the [Baking specification](https://github.com/mozilla/openbadges-specification/blob/master/Badge-Baking/latest.md). |
 | evidence | URL | URL of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. |
 | expires | [DateTime](#datetime) | If the achievment has some notion of expiry, this indicates when a badge should no longer be considered valid. |
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -700,13 +700,15 @@ To assert structural validity, Displayers __should__ ensure the following badge 
 	* `identity`: __must__ be ***text***
 	* `hashed` (_optional_): __must__ be ***boolean***
 	* `salt` (_optional_): __must__ be ***text***
-	* `image` (_optional_): __must__ be a valid ***URL*** or ***Data URL***
+* `image` (_optional_): __must__ be a valid ***URL*** or ***Data URL***
 * `evidence` (_optional_): __must__ be a valid ***URL***
 * `issuedOn` (_optional_): __must__ be a valid ***DateTime***
 * `expires` (_optional_): __must__ be a valid ***DateTime***
 * `verify`: __must__ be an object
 	* `type`: __must__ be either "hosted" or "signed"
 	* `url`: __must__ be a ***URL***
+
+Displayers __should__ also check that the recipient email address matches the address of the person claiming the badge. This may involve hashing the claimed email (using the `salt` value from the `recipient` object if supplied) and comparing it to the `identity` field in the `recipient` object.
 
 Displayers may __optionally__ verify that a badge award does not exceed any expiry date included in the Badge Assertion `expires` field.
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -521,11 +521,119 @@ __Issuer Organization__
 
 #### Examples
 
+The three main elements of a badge are: Badge Assertion; Badge Class; Issuer Organization.
+
+The [Badge Assertion](#badge-assertion) may be represented within a hosted JSON file or a JSON Web Signature (JWS). A Badge Assertion describes a badge awarded to an earner:
+
+```json
+{
+	"uid": "a1b2c3d4e5f6g7",
+	"recipient": {
+	"type": "email",
+		"hashed": true,
+		"salt": "deadsea",
+		"identity": "sha256$c7ef86405ba71b85acd8e2e95166c4b111448089f2e1599f42fe1bba46e865c5"
+	},
+	"image": "https://example.org/beths-robot-badge.png",
+	"evidence": "https://example.org/beths-robot-work.html",
+	"issuedOn": 1359217910,
+	"badge": "https://example.org/robotics-badge.json",
+	"verify": {
+		"type": "hosted",
+		"url": "https://example.org/beths-robotics-badge.json"
+	}
+}
+```
+
+The Badge Assertion links to a [Badge Class](#badge-class) in its `badge` field. This should be a hosted JSON file describing the badge awarded:
+
+```json
+{
+	"name": "Awesome Robotics Badge",
+	"description": "For doing awesome things with robots that people think is pretty great.",
+	"image": "https://example.org/robotics-badge.png",
+	"criteria": "https://example.org/robotics-badge.html",
+	"tags": ["robots", "awesome"],
+	"issuer": "https://example.org/organization.json",
+	"alignment": [
+	{ 
+		"name": "CCSS.ELA-Literacy.RST.11-12.3",
+		"url": "http://www.corestandards.org/ELA-Literacy/RST/11-12/3",
+		"description": "Follow precisely a complex multistep procedure when carrying out experiments, taking measurements, or performing technical tasks; analyze the specific results based on explanations in the text."
+	},
+	{ 
+		"name": "CCSS.ELA-Literacy.RST.11-12.9",
+		"url": "http://www.corestandards.org/ELA-Literacy/RST/11-12/9",
+		"description": " Synthesize information from a range of sources (e.g., texts, experiments, simulations) into a coherent understanding of a process, phenomenon, or concept, resolving conflicting information when possible."
+	}
+	]
+}
+```
+
+The Badge Class includes a link to the [Issuer Organization](#issuer-organization), which describes the issuer of the badge:
+
+```json
+{
+	"name": "amazing Badge Issuer",
+	"image": "https://example.org/logo.png",
+	"url": "https://example.org",
+	"email": "admin@example.org",
+	"revocationList": "https://example.org/revoked.json"
+}
+```
+
+Issuers using signed badges __may__ define a revocation list JSON file in which previously awarded badges can be revoked (included in the `revocationList` field in the Issuer Organization):
+
+```json
+{
+ "qp8g1s": "Issued in error",
+ "2i9016k": "Issued in error",
+ "1av09le": "Honor code violation"
+}
+```
+
 ## Assertion Types
 
-<!--hosted and signed-->
+There are two types of Open Badge: Hosted and Signed. In both cases, the assertion involves three sets of JSON: the Badge Assertion; the Badge Class; the Issuer Organization. The difference between hosted and signed badges relates specifically to the Badge Assertion.
+
+In a hosted badge, the Badge Assertion, Badge Class and Issuer Organization are all stored in hosted files, with the three files linked as follows:
+
+* Badge Assertion `badge` field includes the URL of the Badge Class
+* Badge Class `issuer` field includes the URL of the Issuer Organization
+
+In a signed badge, these links remain the same, but the Badge Assertion is not stored in a hosted JSON file - it is packaged in a JSON Web Signature (JWS). This may be prepared programmatically within the Issuer system whenever a badge is awarded to an Earner.
+
+The Badge Assertion `verify` `type` field should indicate whether a badge is signed or hosted.
+
+### Signed Open Badge Structure
+
+The structure of the JWS comprising a signed Open Badge is as follows:
+
+```
+<encoded JWS header>.<encoded JWS payload>.<encoded JWS signature>
+```
+
+The JSON representation of the badge assertion should be used as the JWS payload. An RSA-SHA256 algorithm should be used for signing.
+
+Example (line breaks for display purposes):
+
+```
+eyJhbGciOiJSUzI1NiJ9
+.
+eyJ1aWQiOiJhYmMtMTIzNCIsInJlY2lwaWVudCI6eyJ0eXBlIjoiZW1haWwiLCJoYXNoZWQiOnRydWUsInNhbHQiOiJkZWFkc2VhIiwiaWQiOiJzaGEyNTYkYzdlZjg2NDA1YmE3MWI4NWFjZDhlMmU5NTE2NmM0YjExMTQ0ODA4OWYyZTE1OTlmNDJmZTFiYmE0NmU4NjVjNSJ9LCJpbWFnZSI6Imh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3QtYmFkZ2UucG5nIiwiZXZpZGVuY2UiOiJodHRwczovL2V4YW1wbGUub3JnL2JldGhzLXJvYm90LXdvcmsuaHRtbCIsImlzc3VlZE9uIjoxMzU5MjE3OTEwLCJiYWRnZSI6Imh0dHBzOi8vZXhhbXBsZS5vcmcvcm9ib3RpY3MtYmFkZ2UuanNvbiIsInZlcmlmeSI6eyJ0eXBlIjoic2lnbmVkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLm9yZy9wdWJsaWNLZXkucGVtIn19
+.
+Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg
+```
+
+The URL of the public key corresponding to the private key used for signing should be included in the Badge Assertion `verify` `url` field. This allows badge Displayers to verify that a signed badge is legitimate.
 
 ## Additional Properties
+
+Additional properties may be included in Open Badges providing they don't clash with the specified properties. **Processors should preserve all properties when rehosting or retransmitting**.
+
+Any additional properties __should__ be namespaced to avoid clashing with future properties. For example, if the issuer at **example.org** wants to add a `foo` property to the assertion, the property name should be `example.org:foo`. This will help prevent unforseen errors should an `foo` property be defined in a later version of the specification.
+
+Discussions regarding extensions to the Open Badge structures can be found here: https://github.com/mozilla/openbadges-discussion/issues/20
 
 ## Issuer Implementations
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -264,7 +264,7 @@ URL of any evidence that the Earner met the requirements for the badge.
 
 A date from which the achievement represented by the badge should be considered invalid.
 
-##### IdentityObject
+##### Identity Object
 
 Defines the identity of the Earner awarded this badge.
 
@@ -340,7 +340,7 @@ A Badge Class __must__ include:
 A Badge Class __may__ include:
 
 * [`alignment`](#badge-class-alignment)
-* ['tags`](#badge-class-tags)
+* [`tags`](#badge-class-tags)
 
 The data types and purpose of these properties are as follows.
 
@@ -374,11 +374,91 @@ _If the badge represents an educational achievement, issuers should consider mar
 URL of the [Issuer Organization](#issuer-organization) for the badge.
 
 <a name="badge-class-alignment"></a>
+* `alignment : <[`[`AlignmentObject`](#alignment-object)`]>` _optional_
+
+Array of objects describing any educational standards the badge aligns to.
 
 <a name="badge-class-tags"></a>
+* `tags : <[text]>` _optional_
+
+Array of text tags describing the type of skill, activity or achievement the badge represents.
+
+##### Alignment Object
+
+Describes an education standard that the badge aligns to.
+
+Badge Class does not require AlignmentObjects - where present, AlignmentObject __must__ include:
+
+* [`name`](#alignment-object-name)
+* [`url`](#alignment-object-url)
+
+AlignmentObject __may__ include:
+
+* [`description`](#alignment-object-description)
+
+The data types and purpose of these properties are as follows.
+
+<a name="alignment-object-name"></a>
+* `name : <text>` __required__
+
+Name of the standard aligned to.
+
+<a name="alignment-object-url"></a>
+* `url : <url>` __required__
+
+URL for the official description of the standard aligned to.
+
+<a name="alignment-object-description"></a>
+* `description : <text>` _optional_
+
+Short description of the standard the badge aligns to.
 
 <a name="issuer-organization"></a>
 ### Issuer Organization
+
+An Issuer Organization is a JSON file describing an Issuer of Open Badges.
+
+#### Properties
+
+An Issuer Organization __must__ include:
+* [`name`](#issuer-organization-name)
+* [`url`](#issuer-organization-url)
+
+An Issuer Organization __may__ include:
+
+* [`description`](#issuer-organization-description)
+* [`image`](#issuer-organization-image)
+* [`email`](#issuer-organization-email)
+* [`revocationList`](#issuer-organization-revocationlist)
+
+The data types and purpose of these properties are as follows.
+
+<a name="issuer-organization-name"></a>
+* `name : <text>` __required__
+
+The name of the issuing organization.
+
+<a name="issuer-organization-url"></a>
+* `url : <url>` __required__
+
+URL of the issuing organization.
+
+<a name="issuer-organization-description"></a>
+* `description : <text>` _optional_
+
+Short description of the issuing organization.
+
+<a name="issuer-organization-image"></a>
+* `image : <url>` _optional_
+
+URL or DataURL for an image representing the issuing organization.
+
+<a name="issuer-organization-revocationlist"></a>
+* `revocationList : <url>` _optional_
+
+URL for list of revoked badges - _only for signed badges_.
+
+___The revocationList endpoint should be a JSON representation of an object where the keys are the uids for revoked badge assertions and the values are the reason for revocation.___
 
 #### Summary Tables
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -1,4 +1,52 @@
-# Assertion
+# Open Badges Assertion Specification
+
+## Status of This Document
+
+## Abstract
+
+## Table of Contents
+
+## Introduction
+
+## Conventions Used in This Document
+
+> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Intended Audience
+
+## Terminology
+
+## Concepts
+
+## Data Model
+
+### Badge Assertion
+
+### Badge Class
+
+### Issuer Organization
+
+#### Summary Tables
+
+(see http://tools.ietf.org/html/rfc2360#section-3.2)
+
+#### Examples
+
+## Issuer Implementations
+
+(considerations)
+
+## Displayer Implementations
+
+(considerations)
+
+## History
+
+(explanation of decisions)
+
+## References
+
+---
 
 An assertion is a representation of an awarded badge. Assertions are used to share information about earned badges, for example via backpacks. An assertion includes information about:
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -231,35 +231,28 @@ Unique Identifier for the badge assertion. This should be locally unique on a pe
 Definition of Earner identity.
 
 <a name="assertion-badge"></a>
-* `badge : <url>` __required__
-
+* `badge : <url>` __required__<br/>
 URL of the [Badge Class](#badge-class) describing the badge awarded.
 
 <a name="assertion-verify"></a>
-* `verify : `[`VerificationObject`](#verification-object) __required__
-
+* `verify : `[`VerificationObject`](#verification-object) __required__<br/>
 Data to aid badge verification.
 
 <a name="assertion-issued-on"></a>
-* `issuedOn : <DateTime>` __required__
-
+* `issuedOn : <DateTime>` __required__<br/>
 Either an ISO 8601 date or a standard 10-digit Unix timestamp indicating the date of the badge award.
 
 <a name="assertion-image"></a>
-* `image : <url>` _optional_
-
-URL or DataURL for the badge image. This must be a PNG or SVG image, and should have the assertion data baked into it.
-
+* `image : <url>` _optional_<br/>
+URL or DataURL for the badge image. This must be a PNG or SVG image, and should have the assertion data baked into it.<br/>
 _The Badge Assertion image is distinct from the Badge Class image, which is the same for all awards of a badge - the Badge Assertion image may be baked in which case it is unique to the Badge Assertion._
 
 <a name="assertion-evidence"></a>
-* `evidence : <url>` _optional_
-
+* `evidence : <url>` _optional_<br/>
 URL of any evidence that the Earner met the requirements for the badge.
 
 <a name="assertion-expires"></a>
-* `expires : <DateTime>` _optional_
-
+* `expires : <DateTime>` _optional_<br/>
 A date from which the achievement represented by the badge should be considered invalid.
 
 ##### Identity Object
@@ -279,23 +272,19 @@ IdentityObject __may__ contain:
 The data types and purpose of these properties are as follows.
 
 <a name="identity-object-identity"></a>
-* `identity : <text>` __required__
-
+* `identity : <text>` __required__<br/>
 Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, an hash should be used. Hash string should be preceded by a dollar sign (`$`) and the algorithm used to generate the hash.
 
 <a name="identity-object-type"></a>
-* `type : <text>` __required__
-
+* `type : <text>` __required__<br/>
 The type of identity value - __currently only "email" is supported__.
 
 <a name="identity-object-hashed"></a>
-* `hashed : <boolean>` __required__
-
+* `hashed : <boolean>` __required__<br/>
 Boolean indicator of whether or not the [`identity`](#identity-object-identity) value is hashed.
 
 <a name="identity-object-salt"></a>
-* `salt : <text>` _optional_
-
+* `salt : <text>` _optional_<br/>
 Hashed [`identity`](#identity-object-identity) values may be salted. If the recipient is [hashed](#identity-object-hashed), `salt` should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
 
 ##### Verification Object
@@ -310,15 +299,12 @@ VerificationObject __must__ include:
 The data types and purpose of these properties are as follows.
 
 <a name="verification-object-type"></a>
-* `type : <text>` __required__
-
+* `type : <text>` __required__<br/>
 The type of verification - __must__ be either "hosted" or "signed".
 
 <a name="verification-object-url"></a>
-* `url : <url>` __required__
-
-For "hosted" [type](#verification-object-type) - the URL of the [Badge Assertion](#badge-assertion) JSON. 
-    
+* `url : <url>` __required__<br/>
+For "hosted" [type](#verification-object-type) - the URL of the [Badge Assertion](#badge-assertion) JSON.<br/>
 For "signed" [type](#verification-object-type) - the URL of the Issuer's public key (corresponding to the private key used to sign the assertion data).
 
 <a name="badge-class"></a>
@@ -343,42 +329,33 @@ A Badge Class __may__ include:
 The data types and purpose of these properties are as follows.
 
 <a name="badge-class-name"></a>
-* `name : <text>` __required__
-
+* `name : <text>` __required__<br/>
 Name of the badge.
 
 <a name="badge-class-description"></a>
-* `description : <text>` __required__
-
+* `description : <text>` __required__<br/>
 Short description of the badge achievement.
 
 <a name="badge-class-image"></a>
-* `image : <url>` __required__
-
-URL or DataURL of the image for the badge.
-
+* `image : <url>` __required__<br/>
+URL or DataURL of the image for the badge.<br/>
 _The Badge Class `image` is the generic image used to represent all awards of the badge as opposed to a baked badge image with a particular Badge Assertion embedded into it - this may be included in a Badge Assertion [`image`](#assertion-image) field._
 
 <a name="badge-class-criteria"></a>
-* `criteria : <url>` __required__
-
-URL of the criteria for earning the badge. 
-
+* `criteria : <url>` __required__<br/>
+URL of the criteria for earning the badge.<br/>
 _If the badge represents an educational achievement, issuers should consider marking up this up with LRMI._
 
 <a name="badge-class-issuer"></a>
-* `issuer : <url>` __required__
-
+* `issuer : <url>` __required__<br/>
 URL of the [Issuer Organization](#issuer-organization) for the badge.
 
 <a name="badge-class-alignment"></a>
-* `alignment : <[`[`AlignmentObject`](#alignment-object)`]>` _optional_
-
+* `alignment : <[`[`AlignmentObject`](#alignment-object)`]>` _optional_<br/>
 Array of objects describing any educational standards the badge aligns to.
 
 <a name="badge-class-tags"></a>
-* `tags : <[text]>` _optional_
-
+* `tags : <[text]>` _optional_<br/>
 Array of text tags describing the type of skill, activity or achievement the badge represents.
 
 ##### Alignment Object
@@ -397,18 +374,15 @@ AlignmentObject __may__ include:
 The data types and purpose of these properties are as follows.
 
 <a name="alignment-object-name"></a>
-* `name : <text>` __required__
-
+* `name : <text>` __required__<br/>
 Name of the standard aligned to.
 
 <a name="alignment-object-url"></a>
-* `url : <url>` __required__
-
+* `url : <url>` __required__<br/>
 URL for the official description of the standard aligned to.
 
 <a name="alignment-object-description"></a>
-* `description : <text>` _optional_
-
+* `description : <text>` _optional_<br/>
 Short description of the standard the badge aligns to.
 
 <a name="issuer-organization"></a>
@@ -432,31 +406,25 @@ An Issuer Organization __may__ include:
 The data types and purpose of these properties are as follows.
 
 <a name="issuer-organization-name"></a>
-* `name : <text>` __required__
-
+* `name : <text>` __required__<br/>
 The name of the issuing organization.
 
 <a name="issuer-organization-url"></a>
-* `url : <url>` __required__
-
+* `url : <url>` __required__<br/>
 URL of the issuing organization.
 
 <a name="issuer-organization-description"></a>
-* `description : <text>` _optional_
-
+* `description : <text>` _optional_<br/>
 Short description of the issuing organization.
 
 <a name="issuer-organization-image"></a>
-* `image : <url>` _optional_
-
+* `image : <url>` _optional_<br/>
 URL or DataURL for an image representing the issuing organization.
 
 <a name="issuer-organization-revocationlist"></a>
-* `revocationList : <url>` _optional_
-
-URL for list of revoked badges - _only for signed badges_.
-
-___The revocationList endpoint should be a JSON representation of an object where the keys are the uids for revoked badge assertions and the values are the reason for revocation.___
+* `revocationList : <url>` _optional_<br/>
+URL for list of revoked badges - _only for signed badges_.<br/>
+_The revocationList endpoint should be a JSON representation of an object where the keys are the uids for revoked badge assertions and the values are the reason for revocation._
 
 #### Summary Tables
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -120,7 +120,7 @@ In the context of the OBI, a badge is loosely described as a digital representat
 <a name="term-badge-class"></a>
 __Badge Class__
 
-The Badge Class forms part of an Open Badge Assertion. The Badge Class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A Badge Class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the [Badge Assertion](#term-badge-assertion) for each award of the badge described. The Badge Class file __must__ include a link to the [Issuer Organization](#term-issuer-organization).
+The Badge Class forms part of an Open Badge Assertion. The Badge Class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A Badge Class will typically be hosted in a JSON file at a stable URL, with a link to this file included in the [Badge Assertion](#term-badge-assertion) for each award of the badge described. The Badge Class file __must__ include a link to the [Issuer Organization](#term-issuer-organization).
 
 <a name="term-bake"></a>
 __Bake, Baking, Baked Badge__
@@ -180,7 +180,7 @@ The OBI is a set of software tools and specifications to support Open Badge syst
 <a name="term-revoke"></a>
 __Revoke__
 
-Badge [Issuers](#term-issuer) can revoke badges they awarded to [Earners](#term-earner). In such cases, the [Issuer Organization](#term-issuer-organization) __should__ include a link to a list of ___signed___ badges that have been revoked, and requests for __hosted__ badge URLs that have been revoked __should__ return a revocation response. Badge Displayers __should not__ display revoked badges and should check revocation status during [verification](#term-verify).
+Badge [Issuers](#term-issuer) can revoke badges they awarded to [Earners](#term-earner). In such cases, the [Issuer Organization](#term-issuer-organization) __should__ include a link to a list of ___signed___ badges that have been revoked, and requests for __hosted__ badge URLs that have been revoked __should__ return a revocation response. Badge Displayers __should not__ display revoked badges and __should__ check revocation status during [verification](#term-verify).
 
 <a name="term-signed-badge"></a>
 __Signed Badge__
@@ -238,7 +238,7 @@ The data type and purpose of each property is as follows.
 
 <a name="assertion-uid"></a>
 * `uid : <text>` __required__<br/>
-Unique Identifier for the Badge Assertion. This __should__ be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
+Unique Identifier for the Badge Assertion. This __should__ be locally unique on a per-origin basis, not globally unique. Badge Issuers __should__ use a unique `uid` value for each Badge Assertion they create (each badge award).
 
 <a name="assertion-recipient"></a>
 * `recipient : `[`IdentityObject`](#identity-object) __required__<br/>
@@ -288,7 +288,7 @@ The data type and purpose of each property is as follows.
 
 <a name="identity-object-identity"></a>
 * `identity : <text>` __required__<br/>
-Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, a hash __should__ be used. The hash string __should__ be preceded by the algorithm used to generate the hash (e.g. `sha256`) and a dollar sign (`$`).
+Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, it is __recommended__ that a hash be used. The hash string __should__ be preceded by the algorithm used to generate the hash (e.g. `sha256`) and a dollar sign (`$`).
 
 <a name="identity-object-type"></a>
 * `type : <text>` __required__<br/>
@@ -627,7 +627,7 @@ The structure of the JWS comprising a ___signed___ Open Badge is as follows:
 <encoded JWS header>.<encoded JWS payload>.<encoded JWS signature>
 ```
 
-The JSON representation of the Badge Assertion __must__ be used as the JWS payload. An RSA-SHA256 algorithm __should__ be used for signing.
+The JSON representation of the Badge Assertion __must__ be used as the JWS payload. An RSA-SHA256 algorithm is __recommended__ for signing.
 
 Example (line breaks for display purposes):
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -135,17 +135,17 @@ A definition of the requirements for earning a badge. The criteria for a badge _
 <a name="term-displayer"></a>
 __Displayer__
 
-A badge Displayer presents information about public badge awards in a digital context. Badge [Earners](#term-earner) can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
+A badge Displayer presents information about public badge awards in a digital context. Badge [Earners](#term-earner) can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers require an understanding of the Assertion structure in order to extract and display the relevant data within their applications. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
 
 <a name="term-earner"></a>
 __Earner__
 
-An Earner is someone who has been awarded one or more Open Badges. Depending on the badging system, the Earner may apply for a badge, supplying supporting evidence. When an Issuer awards a badge, they build information about the Earner identity into a new Badge Assertion.
+An Earner is someone who has been awarded one or more Open Badges. Depending on the badging system, the Earner may apply for a badge, supplying supporting evidence. When an [Issuer](#term-issuer) awards a badge, they build information about the Earner identity into a new [Badge Assertion](#term-badge-assertion), which links to information about what the badge represents.
 
 <a name="term-evidence"></a>
 __Evidence__
 
-A Badge Assertion __may__ include a URL representing evidence for the badge award. Depending on the badging system, the Earner may have submitted this evidence as part of an application process. Typically, the Issuer would compared the evidence to the badge [criteria](#term-criteria) in order to make an awarding decision.
+A [Badge Assertion](#term-badge-assertion) __may__ include a URL representing evidence for the badge award. Depending on the badging system, the [Earner](#term-earner) may have submitted this evidence as part of an application process. Typically, the [Issuer](#term-issuer) compares the evidence to the badge [criteria](#term-criteria) in order to make an awarding decision.
 
 <a name="term-hosted-badge"></a>
 __Hosted Badge__
@@ -155,22 +155,22 @@ A ___hosted___ badge is one whose Assertion data is represented using the badge 
 <a name="term-issue"></a>
 __Issue__
 
-Issuing is the act of awarding a badge to an Earner. Typically badge [Issuers](#term-issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an Issuer __must__ create a [Badge Assertion](#term-badge-assertion), which __may__ be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge).
+Issuing is the act of awarding a badge to an [Earner](#term-earner). Badge [Issuers](#term-issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an Issuer __must__ create a [Badge Assertion](#term-badge-assertion), which __may__ be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge).
 
 <a name="term-issuer"></a>
 __Issuer__
 
-An Issuer is a person or organization (or department within an organization) who/ which awards Open Badges to Earners. Typically the Issuer is responsible for designing and creating the badge as well as awarding it. The Issuer may choose to implement various optional processes in a badging system, such as [assessment](#term-assessment).
+An Issuer is a person or organization (or department within an organization) who awards Open Badges to [Earners](#term-earner). Typically the Issuer is responsible for designing and creating the badge as well as awarding it. The Issuer may choose to implement various optional processes in a badging system, such as [assessment](#term-assessment).
 
 <a name="term-issuer-organization"></a>
 __Issuer Organization__
 
-The Issuer Organization is the part of an Open Badge Assertion in which the badge Issuer is described. The Issuer Organization __must__ be included in the [Badge Class](#term-badge-class) by URL. The URL __must__ return a JSON representation of the Issuer, in which fields specify the Issuer name and URL, as well as other optional descriptive properties. Typically the Issuer Organization data will be used to [verify](#term-verify) awarded badges.
+The Issuer Organization is the part of an Open Badge Assertion in which the badge [Issuer](#term-issuer) is described. The Issuer Organization __must__ be included in the [Badge Class](#term-badge-class) by URL. The file includes a JSON representation of the Issuer, in which fields specify the Issuer name and URL, as well as other optional descriptive properties. Typically the Issuer Organization data is used to [verify](#term-verify) awarded badges.
 
 <a name="term-metadata"></a>
 __Metadata__
 
-In the OBI, metadata is information about badges, badge awards and badge Issuers. OBI metadata is defined in JSON as part of the Assertion specification.
+In the OBI, metadata is information about badges, badge awards and badge Issuers. OBI metadata is defined in JSON as part of the Assertion specification. The Assertion metadata structures are designed for interoperability.
 
 <a name="term-obi"></a>
 __Open Badge Infrastructure (OBI)__
@@ -180,41 +180,39 @@ The OBI is a set of software tools and specifications to support Open Badge syst
 <a name="term-revoke"></a>
 __Revoke__
 
-Badge Issuers can revoke badges they awarded to Earners. In such cases, the [Issuer Organization](#term-issuer-organization) __should__ include a list of ___signed___ badges that have been revoked, and/or provide a revocation response to requests at the original Badge Assertion URL. Badge Displayers __should not__ display revoked badges and should check revocation status during [verification](#term-verify).
+Badge [Issuers](#term-issuer) can revoke badges they awarded to [Earners](#term-earner). In such cases, the [Issuer Organization](#term-issuer-organization) __should__ include a link to a list of ___signed___ badges that have been revoked, and requests for __hosted__ badge URLs that have been revoked __should__ return a revocation response. Badge Displayers __should not__ display revoked badges and should check revocation status during [verification](#term-verify).
 
 <a name="term-signed-badge"></a>
 __Signed Badge__
 
-A ___signed___ badge has its Assertion data included in a JSON Web Signature (JWS). Typically a ___signed___ badge still uses hosted JSON files for the [Badge Class](#term-badge-class) and [Issuer Organization](#term-issuer-organization), but the [Badge Assertion](#term-badge-assertion) JSON is itself packaged as a signature. The Badge Assertion includes a [verification](#term-verify) field in which either a ___hosted___ or [___signed___](#term-signed-badge) type is specified.
+A ___signed___ badge has its Assertion data included in a JSON Web Signature (JWS). Typically a ___signed___ badge still uses hosted JSON files for the [Badge Class](#term-badge-class) and [Issuer Organization](#term-issuer-organization), but the [Badge Assertion](#term-badge-assertion) JSON is itself packaged as a signature. The Badge Assertion includes a [verification](#term-verify) field in which either a [___hosted___](#term-hosted) or ___signed___ type is specified.
 
 <a name="term-validate"></a>
 __Validate, Validation, Validator__
 
-Validation is the act of checking a Badge Assertion for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any resources linked within the assertion are available.
+Validation is the act of checking a [Badge Assertion](#term-badge-assertion) for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any linked resources are available.
 
 <a name="term-verify"></a>
 __Verify, Verification__
 
-Verification is the act of checking that a badge was awarded by the Issuer to the Earner. Badge Displayers __should__ carry out verification on badges before displaying them. Badge Issuers __should__ include the information necessary for this verification to be implemented. Verification should be tailored to whether a Badge Assertion is [___signed___](#term-signed-badge) or [___hosted___](#term-hosted-badge).
+Verification is the act of checking that a badge was awarded by the [Issuer](#term-issuer) to the [Earner](#term-earner). Badge [Displayers](#term-displayer) __should__ carry out verification on badges before displaying them. Badge Issuers __should__ include the information necessary for this verification to be implemented in [Badge Assertions](#term-badge-assertion). Verification is tailored to whether a Badge Assertion is [___signed___](#term-signed-badge) or [___hosted___](#term-hosted-badge).
 
 ## Data Model
 
-Open Badges define their structures in JSON. Three JSON files make up an awarded badge: 
+The structure of an Open Badge is defined in JSON. Three JSON excerpts make up an awarded badge: 
 
 * [Badge Assertion](#badge-assertion)
 * [Badge Class](#badge-class)
 * [Issuer Organization](#issuer-organization)
 
-These three include JSON objects, arrays and values. The Badge Assertion includes a field for the URL of the Badge Class, while the Badge Class includes a link to the Issuer Organization.
+These include JSON objects, arrays and values. The Badge Assertion includes a field for the URL of the Badge Class, with the Badge Class including a link to the Issuer Organization.
 
 * A Badge Assertion can be associated with one Badge Class.
 * A Badge Class can be associated with one or more Badge Assertions.
 * A Badge Class can be associated with one Issuer Organization
 * An Issuer Organization can be associated with one or more Badge Classes.
 
-As is outlined in the below sections, the values in the Open Badges JSON files include primitive types such as text string, boolean, DateTime and URL, as well as objects and arrays including nested values.
-
-_Proposals to extend the JSON structures are currently under discussion: https://github.com/mozilla/openbadges-discussion/issues/20_
+As is outlined in the below sections, the values in the Open Badges JSON files include types such as text string, boolean, DateTime and URL, as well as objects and arrays within nested structures.
 
 <a name="badge-assertion"></a>
 ### Badge Assertion
@@ -236,11 +234,11 @@ A Badge Assertion __may__ include:
 * [`evidence`](#assertion-evidence)
 * [`expires`](#assertion-expires)
 
-The data types and purpose of these properties are as follows.
+The data type and purpose of each property is as follows.
 
 <a name="assertion-uid"></a>
 * `uid : <text>` __required__<br/>
-Unique Identifier for the badge assertion. This __should__ be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
+Unique Identifier for the Badge Assertion. This __should__ be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
 
 <a name="assertion-recipient"></a>
 * `recipient : `[`IdentityObject`](#identity-object) __required__<br/>
@@ -265,7 +263,7 @@ _The Badge Assertion image is distinct from the Badge Class image, which is the 
 
 <a name="assertion-evidence"></a>
 * `evidence : <url>` _optional_<br/>
-URL of any evidence that the Earner met the requirements for the badge.<br/>
+URL of evidence supporting the award.<br/>
 _May be a page linking out to other pages if linking directly to the evidence is infeasible._
 
 <a name="assertion-expires"></a>
@@ -286,7 +284,7 @@ IdentityObject __may__ contain:
 
 * [`salt`](#identity-object-salt)
 
-The purpose and data type for each of these properties follow.
+The data type and purpose of each property is as follows.
 
 <a name="identity-object-identity"></a>
 * `identity : <text>` __required__<br/>
@@ -313,7 +311,7 @@ VerificationObject __must__ include:
 * [`type`](#verification-object-type)
 * [`url`](#verification-object-url)
 
-The purpose and data type for each of these properties follow.
+The data type and purpose of each property is as follows.
 
 <a name="verification-object-type"></a>
 * `type : <text>` __required__<br/>
@@ -343,7 +341,7 @@ A Badge Class __may__ include:
 * [`alignment`](#badge-class-alignment)
 * [`tags`](#badge-class-tags)
 
-The purpose and data type for each of these properties follow.
+The data type and purpose of each property is as follows.
 
 <a name="badge-class-name"></a>
 * `name : <text>` __required__<br/>
@@ -356,7 +354,7 @@ Short description of the badge achievement.
 <a name="badge-class-image"></a>
 * `image : <url>` __required__<br/>
 URL or DataURL of the image for the badge.<br/>
-_The Badge Class `image` is the generic image used to represent all awards of the badge as opposed to a baked badge image with a particular Badge Assertion embedded into it - this may be included in a Badge Assertion [`image`](#assertion-image) field._
+_The Badge Class `image` is the generic image used to represent all awards of the badge, as opposed to a baked badge image with a particular Badge Assertion embedded into it - this may be included in a Badge Assertion [`image`](#assertion-image) field._
 
 <a name="badge-class-criteria"></a>
 * `criteria : <url>` __required__<br/>
@@ -377,7 +375,7 @@ Array of text tags describing the type of skill, activity or achievement the bad
 
 ##### Alignment Object
 
-Describes an education standard that the badge aligns to.
+Describes an educational standard that the badge aligns to.
 
 Badge Class does not require AlignmentObjects - where present, AlignmentObject __must__ include:
 
@@ -388,7 +386,7 @@ AlignmentObject __may__ include:
 
 * [`description`](#alignment-object-description)
 
-The purpose and data type for each of these properties follow.
+The data type and purpose of each property is as follows.
 
 <a name="alignment-object-name"></a>
 * `name : <text>` __required__<br/>
@@ -420,7 +418,7 @@ An Issuer Organization __may__ include:
 * [`email`](#issuer-organization-email)
 * [`revocationList`](#issuer-organization-revocationlist)
 
-The purpose and data type for each of these properties follow.
+The data type and purpose of each property is as follows.
 
 <a name="issuer-organization-name"></a>
 * `name : <text>` __required__<br/>
@@ -440,11 +438,11 @@ URL or DataURL for an image representing the issuing organization.
 
 <a name="issuer-organization-email"></a>
 * `email : <text>` _optional_<br/>
-Contact email address for somone at the organization.
+Contact email address for someone at the organization.
 
 <a name="issuer-organization-revocationlist"></a>
 * `revocationList : <url>` _optional_<br/>
-URL for list of revoked badges - _only for signed badges_.<br/>
+URL for list of revoked badges - ___only for signed badges___.<br/>
 _The revocationList endpoint should be a JSON representation of an object where the keys are the uids for revoked assertions and the values are the reason for revocation._
 
 ### Summary Tables
@@ -539,7 +537,7 @@ __Issuer Organization__
 
 The three main elements of a badge are: Badge Assertion; Badge Class; Issuer Organization.
 
-The [Badge Assertion](#badge-assertion) __may__ be represented within a hosted JSON file or a JSON Web Signature (JWS). A Badge Assertion describes a badge awarded to an Earner:
+The [Badge Assertion](#badge-assertion) __must__ be represented within either a hosted JSON file or a JSON Web Signature (JWS). A Badge Assertion describes a badge awarded to an Earner:
 
 ```json
 {
@@ -561,7 +559,7 @@ The [Badge Assertion](#badge-assertion) __may__ be represented within a hosted J
 }
 ```
 
-The Badge Assertion links to a [Badge Class](#badge-class) in its `badge` field. This __must__ be a hosted JSON file describing the badge awarded:
+The Badge Assertion links to a [Badge Class](#badge-class) in its `badge` field. The Badge Class __must__ be a hosted JSON file describing the badge awarded:
 
 ```json
 {
@@ -586,7 +584,7 @@ The Badge Assertion links to a [Badge Class](#badge-class) in its `badge` field.
 }
 ```
 
-The Badge Class includes a link to the [Issuer Organization](#issuer-organization), which describes the issuer of the badge:
+The Badge Class includes a link to the [Issuer Organization](#issuer-organization) in the `issuer` field - this describes the issuer of the badge:
 
 ```json
 {
@@ -610,14 +608,14 @@ Issuers using ___signed___ badges __may__ define a revocation list JSON file in 
 
 ## Assertion Types
 
-There are two types of Open Badge: ___hosted___ and ___signed___. In both cases, the assertion involves three sets of JSON: the Badge Assertion; the Badge Class; the Issuer Organization. The difference between ___hosted___ and ___signed___ badges relates specifically to the Badge Assertion.
+There are two types of Open Badge: ___hosted___ and ___signed___. In both cases, the Assertion involves three excerpts of JSON: the Badge Assertion; the Badge Class; the Issuer Organization. The difference between ___hosted___ and ___signed___ badges relates specifically to the Badge Assertion.
 
 In a ___hosted___ badge, the Badge Assertion, Badge Class and Issuer Organization are all stored in hosted files, with the three files linked as follows:
 
 * Badge Assertion `badge` field includes the URL of the Badge Class
 * Badge Class `issuer` field includes the URL of the Issuer Organization
 
-In a ___signed___ badge, these links remain the same, but the Badge Assertion is not stored in a hosted JSON file - it is packaged in a JSON Web Signature (JWS). This may be prepared programmatically within the Issuer system whenever a badge is awarded to an Earner.
+In a ___signed___ badge, these links remain the same, but the Badge Assertion is not stored in a hosted JSON file - it is packaged in a JSON Web Signature (JWS). This __may__ be prepared programmatically within the Issuer system whenever a badge is awarded to an Earner.
 
 The Badge Assertion `verify` `type` field __must__ indicate whether a badge is ___signed___ or ___hosted___.
 
@@ -645,7 +643,7 @@ The URL of the public key corresponding to the private key used for signing __mu
 
 ## Additional Properties
 
-Additional properties __may__ be included in Open Badges providing they don't clash with the specified properties. **Processors should preserve all properties when rehosting or retransmitting**.
+Additional properties __may__ be included in Open Badges providing they don't clash with the specified properties. ***Processors should preserve all properties when rehosting or retransmitting***.
 
 Any additional properties __should__ be namespaced to avoid clashing with future properties. For example, if the issuer at **example.org** wants to add a `foo` property to the assertion, the property name __should__ be `example.org:foo`. This will help prevent unforseen errors should a `foo` property be defined in a later version of the specification.
 
@@ -657,13 +655,13 @@ Typically a badge Issuer is responsible for creating the three parts of an Open 
 
 The Issuer __must__ host JSON resources at publicly accessible stable locations, with the content-type set to `application/json`. Any resources linked from the Open Badge JSON files __should__ also be at stable URLs.
 
-Where ___signed___ badges are used, the Issuer __must__ also host the public key corresponding to the private key they use for signing at a stable URL. 
+Where ___signed___ badges are used, the Issuer __must__ also host the public key (corresponding to the private key used for signing) at a stable URL. 
 
 ### Badge Revocation
 
 To revoke ___hosted___ badges, Issuers __should__ respond to requests on the revoked Badge Assertions with an HTTP Status of `410 Gone` and a body of `{ "revoked":true }`.
 
-To revoke ___signed___ badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with the Badge Assertion `uid`s as keys and the reason for revocation as values. The revocation list JSON URL __should__ be included in the Issuer Organization `revocatonList` field.
+To revoke ___signed___ badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with the Badge Assertion `uid` as keys and the reason for revocation as values. The revocation list JSON URL __should__ be included in the Issuer Organization `revocationList` field.
 
 ## Displayer Implementations
 
@@ -671,7 +669,7 @@ Open Badge Displayers __should__ carry out verification steps prior to presentin
 
 To verify a ___hosted___ badge, Displayers __should__:
 
-1. Perform an HTTP GET request on the `verify.url` from the Badge Assertion. If the HTTP Status is not eventually 200 OK, assertion __must__ treated as invalid.
+1. Perform an HTTP GET request on the `verify.url` from the Badge Assertion. If the HTTP Status is not eventually 200 OK, the assertion __must__ treated as invalid.
 
 2. [Assert structural validity](#assert-structural-validity).
 
@@ -685,13 +683,13 @@ To verify a ___signed___ badge, Displayers __should__:
 
 4. Extract the `verify.url` property from the Badge Assertion JSON object. If there is no `verify.url` property, or the `verify.url` property does not contain a valid URL, the badge __must__ be treated as invalid.
 
-5. Perform an HTTP GET request on `verify.url` and store public key. If the HTTP status is not 200 OK (either directly or through 3xx redirects), the badge __must__ be treated as invalid.
+5. Perform an HTTP GET request on `verify.url` and store the public key. If the HTTP status is not 200 OK (either directly or through 3xx redirects), the badge __must__ be treated as invalid.
 
 6. With the public key, perform a JWS verification on the JWS object. If the verification fails, the badge __must__ be treated as invalid.
 
 7. Retrieve the revocation list from the Issuer Organization URL and ensure the `uid` of the badge does not appear in the list.
 
-8. If the above steps pass, assertion __may__ be treated as valid.
+8. If the above steps pass, the assertion __may__ be treated as valid.
 
 <a name="assert-structural-validity"></a>
 To assert structural validity, Displayers __should__ ensure the following badge properties:

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -435,6 +435,90 @@ _The revocationList endpoint should be a JSON representation of an object where 
 
 <!--see http://tools.ietf.org/html/rfc2360#section-3.2 for status codes etc-->
 
+<a name="summary-badge-assertion"></a>
+__Badge Assertion__
+
+> M - Mandatory<br/>
+> O - Optional
+
+| Property | Status | Type |
+|:---------|:----------|:----------|
+| [`uid`](#assertion-uid) | M | text |
+| [`recipient`](#assertion-recipient) | M | [IdentityObject](#summary-identity-object) |
+| [`badge`](#assertion-badge) | M | url |
+| [`verify`](#assertion-verify) | M | [VerificationObject](#summary-verification-object) |
+| [`issuedOn`](#assertion-issuedon) | M | DateTime |
+| [`image`](#assertion-image) | O | url |
+| [`evidence`](#assertion-evidence) | O | url |
+| [`expires`](#assertion-expires) | O | DateTime |
+
+<a name="summary-identity-object"></a>
+__IdentityObject__
+
+> M - Mandatory<br/>
+> O - Optional
+
+| Property | Status | Type |
+|:---------|:----------|:----------|
+| [`identity`](#identity-object-identity) | M | text |
+| [`type`](#identity-object-type) | M | text |
+| [`hashed`](#identity-object-hashed) | M | boolean |
+| [`salt`](#identity-object-salt) | O | text |
+
+<a name="summary-verification-object"></a>
+__VerificationObject__
+
+> M - Mandatory<br/>
+> O - Optional
+
+| Property | Status | Type |
+|:---------|:----------|:----------|
+| [`type`](#verification-object-type) | M | text |
+| [`url`](#verification-object-url) | M | url |
+
+<a name="summary-badge-class"></a>
+__Badge Class__
+
+> M - Mandatory<br/>
+> O - Optional
+
+| Property | Status | Type |
+|:---------|:----------|:----------|
+| [`name`](#badge-class-name) | M | text |
+| [`description`](#badge-class-description) | M | text |
+| [`image`](#badge-class-image) | M | url |
+| [`criteria`](#badge-class-criteria) | M | url |
+| [`issuer`](#badge-class-issuer) | M | url |
+| [`alignment`](#badge-class-alignment) | O | `[`[AlignmentObject](#summary-alignment-object)`]` array |
+| [`tags`](#badge-class-tags) | O | `[`text`]` array |
+
+<a name="summary-alignment-object"></a>
+__AlignmentObject__
+
+> M - Mandatory<br/>
+> O - Optional
+
+| Property | Status | Type |
+|:---------|:----------|:----------|
+| [`name`](#alignment-object-name) | M | text |
+| [`url`](#alignment-object-url) | M | url |
+| [`description`](#alignment-object-description) | O | text |
+
+<a name="summary-issuer-organization"></a>
+__Issuer Organization__
+
+> M - Mandatory<br/>
+> O - Optional
+
+| Property | Status | Type |
+|:---------|:----------|:----------|
+| [`name`](#issuer-organization-name) | M | text |
+| [`url`](#issuer-organization-url) | M | url |
+| [`description`](#issuer-organization-description) | O | text |
+| [`image`](#issuer-organization-image) | O | url |
+| [`email`](#issuer-organization-email) | O | text |
+| [`revocationList`](#issuer-organization-revocationlist) | O | url |
+
 #### Examples
 
 ## Assertion Types
@@ -460,6 +544,8 @@ _The revocationList endpoint should be a JSON representation of an object where 
 ## References
 
 ---
+
+_Older version of document below (redraft in progress)_
 
 An assertion is a representation of an awarded badge. Assertions are used to share information about earned badges, for example via backpacks. An assertion includes information about:
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -16,7 +16,7 @@ A hosted assertion is a file containing a well-formed badge assertion in JSON, s
 
 A signed assertion is in the form of a [JSON Web Signature](http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html). The JSON representation of the badge assertion should be used as the JWS payload.
 
-Both hosted and signed assertions can be passed to the Backpack [issuer API](https://github.com/mozilla/openbadges/blob/development/docs/apis/issuer_api.md) to push badges to the earner's Mozilla Backpack. _Signed badges pass a signature rather than a URL._
+Both hosted and signed assertions can be passed to the Backpack [Issuer API](https://github.com/mozilla/openbadges/blob/development/docs/apis/issuer_api.md) to push badges to the earner's Mozilla Backpack. _Signed badges can be pushed by passing a signature rather than a URL._
 
 ## Assertion Specification
 
@@ -198,12 +198,12 @@ The `uid` for each revoked badge is listed together with the reason for revocati
 The badge assertion should live at a publicly accessible URL (for
 example, `https://example.org/beths-robotics-badge.json`). As an issuer, you should make sure you are properly [setting the content-type](#setting-content-type) to `application/json`.
 
-#### Revoking
+#### Revoking Hosted Badges
 
 To mark a hosted assertion as revoked, issuers should respond with an HTTP Status of
 `410 Gone` and a body of `{"revoked": true}`.
 
-### Signed Badges
+### Implementing Signed Badges
 
 A signed badge assertion should be represented as a
 [JSON Web Signature](http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html):
@@ -230,7 +230,7 @@ The public key corresponding to the private key used to the sign the
 badge should be publicly accessible and specified in the `verify.url`
 property of the badge assertion.
 
-#### Revoking
+#### Revoking Signed Badges
 
 To mark a badge as revoked, add an entry to the resource pointed at by
 the IssuerOrganization `revocationList` URL with the **uid** of the
@@ -310,7 +310,7 @@ To verify a hosted badge assertion:
 1. Perform an HTTP GET request on the `verify.url`. If the HTTP Status
 is not eventually 200 OK, assertion MUST BE treated as invalid.
 
-2. Assert structural validity
+2. Assert structural validity.
 
 
 ## <a id="setting-content-type"></a>Setting Content-Type
@@ -367,4 +367,4 @@ Assertions can be checked for validity using the validator, via the Web interfac
 
 ..or programmatically:
 
-[https://github.com/mozilla/openbadges-validator/])(https://github.com/mozilla/openbadges-validator/)
+[https://github.com/mozilla/openbadges-validator/](https://github.com/mozilla/openbadges-validator/)

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -712,6 +712,8 @@ Displayers __should__ also check that the recipient email address matches the ad
 
 Displayers may __optionally__ verify that a badge award does not exceed any expiry date included in the Badge Assertion `expires` field.
 
+It is strongly __recommended__ that a display implementation show the `verify.url` from a Badge Assertion, with the origin (protocol, hostname, port if non-default) highlighted.
+
 ## Validation
 
 While verification relates primarily to ensuring that a badge was awarded to an Earner by an Issuer, validation involves checking that the structures and linked resources within a badge are valid.

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -637,399 +637,79 @@ Discussions regarding extensions to the Open Badge structures can be found here:
 
 ## Issuer Implementations
 
-<!--considerations, includes revocation, setting content type-->
+Typically a badge Issuer is responsible for creating the three parts of an Open Badge, as well as deciding who to award badges to. The Issuer __may__ use a single Issuer Organization file for all of the badges they issue. Each Issuer Organization may be included in the `issuer` field for multiple Badge Classes. In turn, each Badge Class may be included in the `badge` field for multiple Badge Assertions.
+
+The Issuer __must__ host JSON resources at publicly accessible stable locations, with the content-type set to `application/json`. Any resources linked from the Open Badge JSON files should also be at stable URLs.
+
+Where signed badges are used, the Issuer must also host the public key corresponding to the private key they use for signing at a stable URL. 
+
+### Badge Revocation
+
+To revoke hosted badges, Issuers __should__ respond to requests on the revoked Badge Assertions with an HTTP Status of `410 Gone` and a body of `{ "revoked":true }`.
+
+To revoke signed badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with the Badge Assertion `uid`s as keys adn the reason for revocation as values. The revocation list JSON URL should be included in the Issuer Organization `revocatonList` field.
+
+<!--setting content type examples move to sep doc?-->
 
 ## Displayer Implementations
 
-<!--considerations, includes verification-->
+Open Badge Displayers __should__ carry out verification steps prior to presenting awarded badges for output in digital contexts.
+
+To verify a hosted badge, Displayers should:
+
+1. Perform an HTTP GET request on the `verify.url` from the Badge Assertion. If the HTTP Status is not eventually 200 OK, assertion MUST BE treated as invalid.
+
+2. [Assert structural validity](#assert-structural-validity).
+
+To verify a signed badge, Displayers should:
+
+1. Unpack the JWS payload. This will be a JSON string representation of the Badge Assertion.
+
+2. Parse the JSON string into a JSON object. If the parsing operation fails, assertion __must__ be treated as invalid.
+
+3. [Assert structural validity](#assert-structural-validity).
+
+4. Extract the `verify.url` property from the Badge Assertion JSON object. If there is no `verify.url` property, or the `verify.url` property does not contain a valid URL, the badge __must__ be treated as invalid.
+
+5. Perform an HTTP GET request on `verify.url` and store public key. If the HTTP status is not 200 OK (either directly or through 3xx redirects), the badge __must__ be treated as invalid.
+
+6. With the public key, perform a JWS verification on the JWS object. If the verification fails, the badge MUST be treated as invalid.
+
+7. Retrieve the revocation list from the Issuer Organization URL and ensure the `uid` of the badge does not appear in the list.
+
+8. If the above steps pass, assertion __may__ be treated as valid.
+
+<a name="assert-structural-validity"></a>
+To assert structural validity, Displayers should ensure the following badge properties:
+
+* `badge`: __must__ be a valid **URL**. An HTTP GET request __must__ be performed on the URL to ensure eventual 200 OK status.
+* `recipient`: __must__ be an object
+	* `type`: __must__ be a valid type (currently only "email" is supported)
+	* `identity`: __must__ be ***text***
+	* `hashed` (_optional_): __must__ be ***boolean***
+	* `salt` (_optional_): __must__ be ***text***
+	* `image` (_optional_): __must__ be a valid ***URL*** or ***Data URL***
+* `evidence` (_optional_): __must__ be a valid ***URL***
+* `issuedOn` (_optional_): __must__ be a valid ***DateTime***
+* `expires` (_optional_): __must__ be a valid ***DateTime***
+* `verify`: __must__ be an object
+	* `type`: __must__ be either "hosted" or "signed"
+	* `url`: must be a ***URL***
 
 ## Validation
+
+While verification relates primarily to ensuring that a badge was awarded to an Earner by an Issuer, validation involves checking that the structures and linked resources within a badge are valid.
+
+Assertions can be checked for validity using the validator, via the Web interface:
+
+http://validator.openbadges.org/
+
+..or programmatically:
+
+https://github.com/mozilla/openbadges-validator/
 
 ## History
 
 <!--explain working groups etc, in particular explain contentious decisions, "why" as well as "how"-->
 
 ## References
-
----
-
-_Older version of document below (redraft in progress)_
-
-An assertion is a representation of an awarded badge. Assertions are used to share information about earned badges, for example via backpacks. An assertion includes information about:
-
-* who earned the badge
-* what the badge represents
-* who issued the badge
-
-There are two types of assertion: [hosted](#hosted) and [signed](#signed).
-
-## Hosted
-
-A hosted assertion is a file containing a well-formed badge assertion in JSON, served with the content-type `application/json`. This should live at a stable URL on the issuer server (for example, [https://example.org/beths-robotics-badge.json](https://example.org/beths-robotics-badge.json)) - it is the source of truth for the badge and any future verification attempt will hit that URL to make sure the badge exists and was awarded by the issuer.
-
-## Signed
-
-A signed assertion is in the form of a [JSON Web Signature](http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html). The JSON representation of the badge assertion should be used as the JWS payload.
-
-Both hosted and signed assertions can be passed to the Backpack [Issuer API](https://github.com/mozilla/openbadges/blob/development/docs/apis/issuer_api.md) to push badges to the earner's Mozilla Backpack. _Signed badges can be pushed by passing a signature rather than a URL._
-
-## Assertion Specification
-
-Each assertion includes information about the badge award, the badge itself and the issuer who awarded it. This is implemented via the _badge assertion_, _badge class_ and _issuer organization_. See below for a more detailed overview of the structures involved.
-
-### Structures
-
-Fields marked **in bold letters** are mandatory.
-
-### Assertion Data 
-
-_The assertion describes a particular badge awarded to a particular earner._
-
-#### BadgeAssertion
-
-| Property | Status | Expected Type | Description |
-| -------- | -------- | ------------- | ----------- |
-| **uid** | **required** | Text | Unique Identifier for the badge. This is expected to be **locally** unique on a per-origin basis, not globally unique. |
-| **recipient** | **required** | [IdentityObject](#identityobject) | The recipient of the achievement. |
-| **badge** | **required** | URL | URL that describes the type of badge being awarded. The endpoint should be a [BadgeClass](#badgeclass) |
-| **verify** | **required** | [VerificationObject](#verificationobject) | Data to help a third party verify this assertion. |
-| **issuedOn** | **required** | [DateTime](#primitives) | Date that the achievement was awarded. |
-| image | _optional_ | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing this achievement. This must be a PNG image, and if possible, the image should be prepared via the [Baking specification](https://github.com/mozilla/openbadges-specification/blob/master/Badge-Baking/latest.md). |
-| evidence | _optional_ | URL | URL of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. |
-| expires | _optional_ | [DateTime](#primitives) | If the achievment has some notion of expiry, this indicates when a badge should no longer be considered valid. |
-
-
-#### <a id="identity-object"></a>IdentityObject
-
-| Property | Status | Expected Type | Description |
-|--------|--------|------------|-----------|
-|**identity** | **required** | [IdentityHash](#primitives) or Text | Either the hash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information, it is strongly recommended that an IdentityHash be used.|
-|**type** | **required** | [IdentityType](#primitives) | The type of identity.|
-|**hashed** | **required** | Boolean | Whether or not the `id` value is hashed.|
-|salt | _optional_ | Text | If the recipient is hashed, this should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.|
-
-
-#### <a id="verification-object"></a>VerificationObject
-
-| Property | Status | Expected Type | Description |
-|--------|--------|------------|-----------|
-|**type** | **required** | VerificationType | The type of verification method.|
-|**url** | **required** | URL | If the type is "hosted", this should be a URL pointing to the assertion on the issuer's server. If the type is "signed", this should be a link to the issuer's public key.|
-
-### Badge Class Data
-
-_The badge class describes what the badge represents._
-
-#### <a id="badge-class"></a>BadgeClass
-
-| Property | Status | Expected Type | Description |
-|--------|--------|------------|-----------|
-|**name** | **required** | Text | The name of the achievement.|
-|**description** | **required** | Text | A short description of the achievement.|
-|**image** | **required** | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing the achievement.|
-|**criteria** | **required** | URL | URL of the criteria for earning the achievement. If the badge represents an educational achievement, consider marking up this up with [LRMI](http://www.lrmi.net/)|
-|**issuer** | **required** | URL | URL of the organization that issued the badge. Endpoint should be an [IssuerOrganization](#issuerorganization)|
-|alignment | _optional_ | Array of [AlignmentObjects](#alignmentobject) | List of objects describing which educational standards this badge aligns to, if any.|
-|tags | _optional_ | Array of Text | List of tags that describe the type of achievement.|
-
-
-#### <a id="alignment-object"></a>AlignmentObject 
-
-_AlignmentObject is optional - fields below are required **if** it is included in the BadgeClass._
-
-| Property | Status | Expected Type | Description|
-|--------|--------|------------|-----------|
-|**name** | **required** | Text | Name of the alignment.|
-|**url** | **required** | URL | URL linking to the official description of the standard.|
-|description | _optional_ | Text | Short description of the standard.|
-
-### Issuer Data
-
-_The Issuer Organization describes who issued the badge._
-
-#### <a id="issuer-organization"></a>IssuerOrganization
-
-| Property | Status | Expected Type | Description |
-|--------|--------|------------|-----------|
-|**name** | **required** | Text | The name of the issuing organization.|
-|**url** | **required** | URL | URL of the institution.|
-|description | _optional_ | Text | A short description of the institution.|
-|image | _optional_ | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | An image representing the institution.|
-|email | _optional_ | Text | Contact address for someone at the organization.|
-|revocationList | _optional_ | URL |  URL of the Badge Revocation List. The endpoint should be a JSON representation of an object where the keys are the **uid** a revoked badge assertion, and the values are the reason for revocation. This is only necessary for signed badges.|
-
-
-### <a id="additional-properties"></a>Additional Properties
-
-Additional properties are allowed so long as they don't clash with specified
-properties. **Processors should preserve all properties when rehosting or
-retransmitting**.
-
-Any additional properties SHOULD be namespaced to avoid clashing with
-future properties. For example, if the issuer at **example.org** wants
-to add a `foo` property to the assertion, the property name should be
-`example.org:foo`. This will help prevent unforseen errors should an
-`foo` property be defined in a later version of the specification.
-
-If a property would be useful beyond internal use, proposals for
-standardizing can be sent to
-[the openbadges-dev mailing list](https://groups.google.com/forum/?fromgroups#!forum/openbadges-dev).
-
-### Primitives
-
-* Boolean
-* Text
-* Array
-* <a id="date-time"></a>DateTime - Either an [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) date or a standard 10-digit Unix timestamp.
-* URL - Fully qualified URL, including protocol, host, port if applicable, and path.
-* <a id="identity-type"></a>IdentityType - Type of identity being represented. Currently the only supported value is "email"
-* <a id="identity-hash"></a>IdentityHash - A hash string preceded by a dollar sign ("$") and the algorithm used to generate the hash. For example: `sha256$28d50415252ab6c689a54413da15b083034b66e5` represents the result of calculating a SHA256 on the string "mayze". For more information, see [how to hash & salt in various languages](https://github.com/mozilla/openbadges/wiki/How-to-hash-&-salt-in-various-languages.).
-* <a id="verification-type"></a>VerificationType - Type of verification. Can be either "hosted" or "signed".
-
-## JSON Examples
-
-Three JSON files are necessary to create a valid assertion:
-
-* _Badge Assertion:_ contains information regarding a specific badge that was awarded to a user, e.g. `https://example.org/beths-robotics-badge.json`:
-```json
-{
-  "uid": "f2c20",
-  "recipient": {
-    "type": "email",
-    "hashed": true,
-    "salt": "deadsea",
-    "identity": "sha256$c7ef86405ba71b85acd8e2e95166c4b111448089f2e1599f42fe1bba46e865c5"
-  },
-  "image": "https://example.org/beths-robot-badge.png",
-  "evidence": "https://example.org/beths-robot-work.html",
-  "issuedOn": 1359217910,
-  "badge": "https://example.org/robotics-badge.json",
-  "verify": {
-    "type": "hosted",
-    "url": "https://example.org/beths-robotics-badge.json"
-  }
-}
-```
-
-* _Badge Class:_ contains information about a badge and what it represents, e.g. `https://example.org/robotics-badge.json`:
-```json
-{
-  "name": "Awesome Robotics Badge",
-  "description": "For doing awesome things with robots that people think is pretty great.",
-  "image": "https://example.org/robotics-badge.png",
-  "criteria": "https://example.org/robotics-badge.html",
-  "tags": ["robots", "awesome"],
-  "issuer": "https://example.org/organization.json",
-  "alignment": [
-    { "name": "CCSS.ELA-Literacy.RST.11-12.3",
-      "url": "http://www.corestandards.org/ELA-Literacy/RST/11-12/3",
-      "description": "Follow precisely a complex multistep procedure when carrying out experiments, taking measurements, or performing technical tasks; analyze the specific results based on explanations in the text."
-    },
-    { "name": "CCSS.ELA-Literacy.RST.11-12.9",
-      "url": "http://www.corestandards.org/ELA-Literacy/RST/11-12/9",
-      "description": " Synthesize information from a range of sources (e.g., texts, experiments, simulations) into a coherent understanding of a process, phenomenon, or concept, resolving conflicting information when possible."
-    }
-  ]
-}
-```
-
-* _Issuer Organization:_ contains information about who issued a badge, e.g. `https://example.org/organization.json`:
-```json
-{
-  "name": "An Example Badge Issuer",
-  "image": "https://example.org/logo.png",
-  "url": "https://example.org",
-  "email": "steved@example.org",
-  "revocationList": "https://example.org/revoked.json"
-}
-```
-
-Signed badges can optionally be accompanied by a __Revocation list__ (also represented in JSON), which defines badges that have been revoked, e.g. `https://example.org/revoked.json`:
-
-```json
-{
-  "qp8g1s": "Issued in error",
-  "2i9016k": "Issued in error",
-  "1av09le": "Honor code violation"
-}
-```
-
-The `uid` for each revoked badge is listed together with the reason for revocation. Displayers are expected to check the revocation list before displaying a badge.
-
-## <a id="implementation"></a> Implementation
-
-### Implementing Hosted Badges
-
-The badge assertion should live at a publicly accessible URL (for
-example, `https://example.org/beths-robotics-badge.json`). As an issuer, you should make sure you are properly [setting the content-type](#setting-content-type) to `application/json`.
-
-#### Revoking Hosted Badges
-
-To mark a hosted assertion as revoked, issuers should respond with an HTTP Status of
-`410 Gone` and a body of `{"revoked": true}`.
-
-### Implementing Signed Badges
-
-A signed badge assertion should be represented as a
-[JSON Web Signature](http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html):
-
-```
-<encoded JWS header>.<encoded JWS payload>.<encoded JWS signature>
-```
-
-The JSON representation of the badge assertion should be used as the JWS
-payload. For compatibility purposes, using an RSA-SHA256 is highly
-recommended.
-
-An example, with linebreaks for display purposes:
-
-```
-eyJhbGciOiJSUzI1NiJ9
-.
-eyJ1aWQiOiJhYmMtMTIzNCIsInJlY2lwaWVudCI6eyJ0eXBlIjoiZW1haWwiLCJoYXNoZWQiOnRydWUsInNhbHQiOiJkZWFkc2VhIiwiaWQiOiJzaGEyNTYkYzdlZjg2NDA1YmE3MWI4NWFjZDhlMmU5NTE2NmM0YjExMTQ0ODA4OWYyZTE1OTlmNDJmZTFiYmE0NmU4NjVjNSJ9LCJpbWFnZSI6Imh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3QtYmFkZ2UucG5nIiwiZXZpZGVuY2UiOiJodHRwczovL2V4YW1wbGUub3JnL2JldGhzLXJvYm90LXdvcmsuaHRtbCIsImlzc3VlZE9uIjoxMzU5MjE3OTEwLCJiYWRnZSI6Imh0dHBzOi8vZXhhbXBsZS5vcmcvcm9ib3RpY3MtYmFkZ2UuanNvbiIsInZlcmlmeSI6eyJ0eXBlIjoic2lnbmVkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLm9yZy9wdWJsaWNLZXkucGVtIn19
-.
-Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg
-```
-
-The public key corresponding to the private key used to sign the
-badge should be publicly accessible and specified in the `verify.url`
-property of the badge assertion.
-
-#### Revoking Signed Badges
-
-To mark a badge as revoked, add an entry to the resource pointed at by
-the IssuerOrganization `revocationList` URL with the **uid** of the
-badge and a reason why the badge is being revoked.
-
-For example, to mark a badge with the uid "abc-1234" as revoked, the
-`revocationList` URL would respond with
-
-```json
-{"abc-1234" : "Issued in error"}
-```
-
-## Badge Verification
-
-An assertion will either be raw JSON (hosted assertion) or a JWS object
-(signed assertion)
-
-It is STRONGLY RECOMMENDED that a display implementation
-show the `verify.url`, with the origin (protocol, hostname, port if
-non-default) highlighted.
-
-The use of the term "eventual 200 OK" is meant to mean that 3xx
-redirects are allowed, as long as the request eventually terminates on a
-resource that returns a 200 OK.
-
-### Structural Validity
-
-The following overview indicates the requirements for a badge assertion to be considered structurally valid:
-
-* `badge`: must be a valid **URL**. An HTTP GET request MUST BE
-  performed on the URL to ensure eventual 200 OK status.
-* `recipient`: must be an object
-  * `type`: must be a valid type (currently, only "email" is supported)
-  * `identity`: must be a **text**
-  * `hashed` (optional): must be **boolean**
-  * `salt` (optional): must be **text**
-* `image` (optional): must be a valid **URL** or **Data URL**.
-* `evidence` (optional): must be a valid **URL**
-* `issuedOn` (optional): must be a valid [**DateTime**](#primitives)
-* `expires` (optional): must be a valid [**DateTime**](#primitives)
-* `verify`: must be an object
-  * `type`: must be either "hosted" or "signed"
-  * `url`: must be a **URL**
-
-#### Signed Assertion
-
-To verify a signed badge assertion:
-
-1. Unpack the JWS payload. This will be a JSON string representation of
-the badge assertion.
-
-2. Parse the JSON string into a JSON object. If the parsing operation
-fails, assertion MUST be treated as invalid.
-
-3. Assert structural validity.
-
-4. Extract the `verify.url` property from the JSON object. If there is no
-`verify.url` property, or the `verify.url` property does not contain a valid
-URL, assertion MUST be treated as invalid.
-
-5. Perform an HTTP GET request on `verify.url` and store public key. If the
-HTTP status is not 200 OK (either directly or through 3xx redirects),
-the assertion MUST be treated as invalid.
-
-6. With the public key, perform a JWS verification on the JWS object. If
-the verification fails, assertion MUST be treated as invalid.
-
-7. Retrieve the revocation list from the IssuerOrganization object and
-ensure the `uid` of the badge does not appear in the list.
-
-8. If the above steps pass, assertion MAY BE treated as valid.
-
-#### Hosted Assertion
-
-To verify a hosted badge assertion:
-
-1. Perform an HTTP GET request on the `verify.url`. If the HTTP Status
-is not eventually 200 OK, assertion MUST BE treated as invalid.
-
-2. Assert structural validity.
-
-
-## <a id="setting-content-type"></a>Setting Content-Type
-
-In the examples below `badge_assertion` is a native dictionary, hash
-or associative array. `badge_assertion_json` is a prepared JSON string.
-
-### PHP
-```javascript
-// Do this before doing anything that starts a response
-header('Content-Type: application/json');
-```
-
-### Drupal 6
-```javascript
-// do not use drupal_json -- it sets the wrong header
-drupal_add_http_header('Content-Type', 'application/json');
-echo drupal_to_js(badge_assertion);
-```
-### Drupal 7
-```javascript
-drupal_json_output(badge_assertion);
-```
-
-### Django
-```python
-HttpResponse(badge_assertion_json, mimetype='application/json')
-```
-
-### Rails
-```ruby
-render :json => badge_assertion
-```
-
-### Apache
-```apache
-# Save your assertions as .json files and add this to your httpd.conf
-AddType application/json        json
-```
-
-### Nginx
-```nginx
-# In your server context, add the following:
-types {
-  applications/json     json;
-}
-```
-
-## Assertion Validator
-
-Assertions can be checked for validity using the validator, via the Web interface:
-
-[http://validator.openbadges.org/](http://validator.openbadges.org/)
-
-..or programmatically:
-
-[https://github.com/mozilla/openbadges-validator/](https://github.com/mozilla/openbadges-validator/)

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -2,6 +2,9 @@
 
 ## Status of This Document
 
+* _depends on track for ietf ie standards/ experimental etc http://tools.ietf.org/html/rfc2223#section-5_
+* _alternative w3c example http://www.w3.org/TR/json-ld/ - overview of document history, participants etc_
+
 ## Abstract
 
 ## Table of Contents

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -207,49 +207,175 @@ A Badge Assertion is a JSON file or JSON Web Signature (JWS) describing an Open 
 
 #### Properties
 
-A Badge Assertion may include the following required and optional properties:
+A Badge Assertion __must__ include:
+* [`uid`](#assertion-uid)
+* [`recipient`](#assertion-recipient)
+* [`badge`](#assertion-badge)
+* [`verify`](#assertion-verify)
+* [`issuedOn`](#assertion-issued-on)
 
-<a name="uid"></a>
-* `uid : "<text>"` __required__
+A Badge Assertion __may__ include:
+
+* [`image`](#assertion-image)
+* ['evidence`](#assertion-evidence)
+* [`expires`](#assertion-expires)
+
+The data types and purpose of these properties are as follows.
+
+<a name="assertion-uid"></a>
+* `uid : <text>` __required__
 
 Unique Identifier for the badge assertion. This should be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
 
-<a name="recipient"></a>
+<a name="assertion-recipient"></a>
 * `recipient : `[`IdentityObject`](#identity-object) __required__
 
 Definition of Earner identity.
 
 <a name="assertion-badge"></a>
-* `badge : "<url>"` __required__
+* `badge : <url>` __required__
 
 URL of the [Badge Class](#badge-class) describing the badge awarded.
 
-##### `IdentityObject`
+<a name="assertion-verify"></a>
+* `verify : `[`VerificationObject`](#verification-object) __required__
 
-Defines the identity of the Earner awarded this badge using the following properties:
+Data to aid badge verification.
 
-<a name="identity"></a>
-* `identity : "<text>"` __required__
+<a name="assertion-issued-on"></a>
+* `issuedOn : <DateTime>` __required__
+
+Either an ISO 8601 date or a standard 10-digit Unix timestamp indicating the date of the badge award.
+
+<a name="assertion-image"></a>
+* `image : <url>` _optional_
+
+URL or DataURL for the badge image. This must be a PNG or SVG image, and should have the assertion data baked into it.
+
+_The Badge Assertion image is distinct from the Badge Class image, which is the same for all awards of a badge - the Badge Assertion image may be baked in which case it is unique to the Badge Assertion._
+
+<a name="assertion-evidence"></a>
+* `evidence : <url>` _optional_
+
+URL of any evidence that the Earner met the requirements for the badge.
+
+<a name="assertion-expires"></a>
+* `expires : <DateTime>` _optional_
+
+A date from which the achievement represented by the badge should be considered invalid.
+
+##### IdentityObject
+
+Defines the identity of the Earner awarded this badge.
+
+IdentityObject __must__ contain:
+
+* [`identity`](#identity-object-identity)
+* [`type`](#identity-object-type)
+* [`hashed`](#identity-object-hashed)
+
+IdentityObject __may__ contain:
+
+* [`salt`](#identity-object-salt)
+
+The data types and purpose of these properties are as follows.
+
+<a name="identity-object-identity"></a>
+* `identity : <text>` __required__
 
 Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, an hash should be used. Hash string should be preceded by a dollar sign (`$`) and the algorithm used to generate the hash.
 
-<a name="identity-type"></a>
-* `type : "<text>"` __required__
+<a name="identity-object-type"></a>
+* `type : <text>` __required__
 
 The type of identity value - __currently only "email" is supported__.
 
-<a name="hashed"></a>
-* `hashed : "<boolean>"` __required__
+<a name="identity-object-hashed"></a>
+* `hashed : <boolean>` __required__
 
-Boolean indicator of whether or not the `identity` value is hashed.
+Boolean indicator of whether or not the [`identity`](#identity-object-identity) value is hashed.
 
-<a name="salt"></a>
-* `salt : "<text>"` _optional_
+<a name="identity-object-salt"></a>
+* `salt : <text>` _optional_
 
-Hashed `identity` values may be salted. If the recipient is hashed, `salt` should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
+Hashed [`identity`](#identity-object-identity) values may be salted. If the recipient is [hashed](#identity-object-hashed), `salt` should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
+
+##### Verification Object
+
+Defines the data required to carry out verification on this badge award.
+
+VerificationObject __must__ include:
+
+* [`type`](#verification-object-type)
+* [`url`](#verification-object-url)
+
+The data types and purpose of these properties are as follows.
+
+<a name="verification-object-type"></a>
+* `type : <text>` __required__
+
+The type of verification - __must__ be either "hosted" or "signed".
+
+<a name="verification-object-url"></a>
+* `url : <url>` __required__
+
+For "hosted" [type](#verification-object-type) - the URL of the [Badge Assertion](#badge-assertion) JSON. 
+    
+For "signed" [type](#verification-object-type) - the URL of the Issuer's public key (corresponding to the private key used to sign the assertion data).
 
 <a name="badge-class"></a>
 ### Badge Class
+
+A Badge Class is a JSON file describing an Open Badge representing a skill, learning experience or achievement.
+
+#### Properties
+
+A Badge Class __must__ include:
+* [`name`](#badge-class-name)
+* [`description`](#badge-class-description)
+* [`image`](#badge-class-image)
+* [`criteria`](#badge-class-criteria)
+* [`issuer`](#badge-class-issuer)
+
+A Badge Class __may__ include:
+
+* [`alignment`](#badge-class-alignment)
+* ['tags`](#badge-class-tags)
+
+The data types and purpose of these properties are as follows.
+
+<a name="badge-class-name"></a>
+* `name : <text>` __required__
+
+Name of the badge.
+
+<a name="badge-class-description"></a>
+* `description : <text>` __required__
+
+Short description of the badge achievement.
+
+<a name="badge-class-image"></a>
+* `image : <url>` __required__
+
+URL or DataURL of the image for the badge.
+
+_The Badge Class `image` is the generic image used to represent all awards of the badge as opposed to a baked badge image with a particular Badge Assertion embedded into it - this may be included in a Badge Assertion [`image`](#assertion-image) field._
+
+<a name="badge-class-criteria"></a>
+* `criteria : <url>` __required__
+
+URL of the criteria for earning the badge. 
+
+_If the badge represents an educational achievement, issuers should consider marking up this up with LRMI._
+
+<a name="badge-class-issuer"></a>
+* `issuer : <url>` __required__
+
+URL of the [Issuer Organization](#issuer-organization) for the badge.
+
+<a name="badge-class-alignment"></a>
+
+<a name="badge-class-tags"></a>
 
 <a name="issuer-organization"></a>
 ### Issuer Organization

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -226,7 +226,7 @@ eyJ1aWQiOiJhYmMtMTIzNCIsInJlY2lwaWVudCI6eyJ0eXBlIjoiZW1haWwiLCJoYXNoZWQiOnRydWUs
 Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg
 ```
 
-The public key corresponding to the private key used to the sign the
+The public key corresponding to the private key used to sign the
 badge should be publicly accessible and specified in the `verify.url`
 property of the badge assertion.
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -26,6 +26,9 @@ Each assertion includes information about the badge award, the badge itself and 
 
 Fields marked **in bold letters** are mandatory.
 
+### Assertion Data 
+
+_The assertion describes a particular badge awarded to a particular earner._
 
 #### BadgeAssertion
 
@@ -58,7 +61,9 @@ Fields marked **in bold letters** are mandatory.
 |**type** | **required** | VerificationType | The type of verification method.|
 |**url** | **required** | URL | If the type is "hosted", this should be a URL pointing to the assertion on the issuer's server. If the type is "signed", this should be a link to the issuer's public key.|
 
+### Badge Class Data
 
+_The badge class describes what the badge represents._
 
 #### <a id="badge-class"></a>BadgeClass
 
@@ -83,6 +88,9 @@ _AlignmentObject is optional - fields below are required **if** it is included i
 |**url** | **required** | URL | URL linking to the official description of the standard.|
 |description | _optional_ | Text | Short description of the standard.|
 
+### Issuer Data
+
+_The Issuer Organization describes who issued the badge._
 
 #### <a id="issuer-organization"></a>IssuerOrganization
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -217,7 +217,7 @@ A Badge Assertion __must__ include:
 A Badge Assertion __may__ include:
 
 * [`image`](#assertion-image)
-* ['evidence`](#assertion-evidence)
+* [`evidence`](#assertion-evidence)
 * [`expires`](#assertion-expires)
 
 The data types and purpose of these properties are as follows.
@@ -249,7 +249,8 @@ _The Badge Assertion image is distinct from the Badge Class image, which is the 
 
 <a name="assertion-evidence"></a>
 * `evidence : <url>` _optional_<br/>
-URL of any evidence that the Earner met the requirements for the badge.
+URL of any evidence that the Earner met the requirements for the badge.<br/>
+_May be a page linking out to other pages if linking directly to the evidence is infeasible._
 
 <a name="assertion-expires"></a>
 * `expires : <DateTime>` _optional_<br/>
@@ -269,15 +270,15 @@ IdentityObject __may__ contain:
 
 * [`salt`](#identity-object-salt)
 
-The data types and purpose of these properties are as follows.
+The purpose and data type for each of these properties follow.
 
 <a name="identity-object-identity"></a>
 * `identity : <text>` __required__<br/>
-Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, an hash should be used. Hash string should be preceded by a dollar sign (`$`) and the algorithm used to generate the hash.
+Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, a hash should be used. The hash string should be preceded by the algorithm used to generate the hash (e.g. `sha256`) and a dollar sign (`$`).
 
 <a name="identity-object-type"></a>
 * `type : <text>` __required__<br/>
-The type of identity value - __currently only "email" is supported__.
+The type of identity value - _currently_ __must__ _be "email"_.
 
 <a name="identity-object-hashed"></a>
 * `hashed : <boolean>` __required__<br/>
@@ -296,11 +297,11 @@ VerificationObject __must__ include:
 * [`type`](#verification-object-type)
 * [`url`](#verification-object-url)
 
-The data types and purpose of these properties are as follows.
+The purpose and data type for each of these properties follow.
 
 <a name="verification-object-type"></a>
 * `type : <text>` __required__<br/>
-The type of verification - __must__ be either "hosted" or "signed".
+The type of verification - __must__ _be either "hosted" or "signed"_.
 
 <a name="verification-object-url"></a>
 * `url : <url>` __required__<br/>
@@ -326,7 +327,7 @@ A Badge Class __may__ include:
 * [`alignment`](#badge-class-alignment)
 * [`tags`](#badge-class-tags)
 
-The data types and purpose of these properties are as follows.
+The purpose and data type for each of these properties follow.
 
 <a name="badge-class-name"></a>
 * `name : <text>` __required__<br/>
@@ -371,7 +372,7 @@ AlignmentObject __may__ include:
 
 * [`description`](#alignment-object-description)
 
-The data types and purpose of these properties are as follows.
+The purpose and data type for each of these properties follow.
 
 <a name="alignment-object-name"></a>
 * `name : <text>` __required__<br/>
@@ -403,7 +404,7 @@ An Issuer Organization __may__ include:
 * [`email`](#issuer-organization-email)
 * [`revocationList`](#issuer-organization-revocationlist)
 
-The data types and purpose of these properties are as follows.
+The purpose and data type for each of these properties follow.
 
 <a name="issuer-organization-name"></a>
 * `name : <text>` __required__<br/>
@@ -420,6 +421,10 @@ Short description of the issuing organization.
 <a name="issuer-organization-image"></a>
 * `image : <url>` _optional_<br/>
 URL or DataURL for an image representing the issuing organization.
+
+<a name="issuer-organization-email"></a>
+* `email : <text>` _optional_<br/>
+Contact email address for somone at the organization.
 
 <a name="issuer-organization-revocationlist"></a>
 * `revocationList : <url>` _optional_<br/>

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -4,20 +4,20 @@
 
 ___To follow___
 
-<!--depends on track for ietf ie standards/ experimental etc http://tools.ietf.org/html/rfc2223#section-5
+<!--depends on track for ietf http://tools.ietf.org/html/rfc2223#section-5
 alternative w3c example http://www.w3.org/TR/json-ld/ - overview of document history, participants etc-->
 
 ## Abstract
 
-The Open Badge Infrastructure (OBI) is a set of software tools and specifications for implementing Open Badge applications. The OBI provides a framework for creating, issuing and displaying Open Badges. The Open Badges Assertion Specification defines the structure of an awarded Open Badge. An Open Badges Assertion uses JSON-structured data to describe a specific badge issued to a specific Earner. The Assertion content facilitates communicating and verifying the achievement that the badge represents.
+The Open Badge Infrastructure (OBI) is a set of software tools and specifications for implementing Open Badge applications. The OBI provides a framework for creating, issuing and displaying Open Badges. The Open Badges Assertion Specification defines the structure of an awarded Open Badge. An Open Badge Assertion uses JSON-structured data to describe a specific badge issued to a specific Earner. The Assertion content facilitates communicating and verifying the achievement that the badge represents.
 
 ## Table of Contents
 
 * [Introduction](#introduction)
 * [Conventions Used in this Document](#conventions-used-in-this-document)
 * [Intended Audience](#intended-audience)
-* [Terminology](#terminology)
 * [Concepts](#concepts)
+* [Terminology](#terminology)
 * [Data Model](#data-model)
 	* [Badge Assertion](#badge-assertion)
 	* [Badge Class](#badge-class)
@@ -36,18 +36,18 @@ The Open Badge Infrastructure (OBI) is a set of software tools and specification
 
 ## Introduction
 
-The Open Badge Infrastructure Assertion specification aims to describe each awarded badge in a way that is open, meaningful and verifiable. An Open Badge Assertion should include all of the information required to understand the award. Each assertion should define these core aspects of a badge award:
+The Open Badge Infrastructure Assertion specification aims to describe the structure of each awarded badge in a way that is open, meaningful and verifiable. An Open Badge Assertion should include all of the information required to understand the award. Each assertion should define these core aspects of a badge award:
 
 * who earned the badge
 * what the badge represents
 * who issued the badge
 
-This typically includes descriptive information about the achievement, an image and the date of issue. Additionally, an assertion should include the following information to aid client implementations:
+This typically comprises descriptive information about the achievement, an image and the date of issue. Additionally, an assertion should include the following information to aid client implementations:
 
 * criteria for earning the badge
 * verification details for the Earner identity and badge award
 
-The Assertion specification defines a series of required and optional properties to fulfill the above aims. Assertions may also include optional information such as evidence, educational standards alignment details and an expiry date.
+The Assertion specification defines a series of required and optional properties to fulfill the above aims. Assertions may include optional information such as evidence, educational standards alignment details and expiry dates.
 
 The purpose of the Assertion specification is to provide a reference for all implementers of Open Badge systems. This primarily means badge Issuers and Displayers.
 
@@ -56,12 +56,11 @@ ___Proposals are currently under discussion regarding extending the Assertion st
 * https://github.com/mozilla/openbadges-discussion/issues/20
 * https://github.com/mozilla/openbadges-specification/issues/5
 
-<!--explain motivation, applicability - this specification is intended to provide... to be used by... explain what obi spec is http://tools.ietf.org/html/rfc2223#section-7
-purpose, intended function, how it fits into context-->
-
 ## Conventions Used in This Document
 
 > The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+<!-- https://www.ietf.org/rfc/rfc2119.txt -->
 
 ## Intended Audience
 
@@ -75,6 +74,20 @@ The primary audience is expected to be software developers, however the specific
 
 The Open Badges Assertion specification relies on JSON syntax, some knowledge of which is required - see [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt) and [JSON.org](http://www.json.org/).
 
+## Concepts
+
+Adopting the OBI involves understanding a range of concepts which refer to well-known real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
+
+An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to Earners. The generic badge is defined using a ___Badge Class___, while an awarded badge is defined using a ___Badge Assertion___. In this sense, a generic badge can be conceptualized as the template for awarded badges. This connection is implemented by linking each ___Badge Assertion___ to a ___Badge Class___.
+
+People who are awarded Open Badges are referred to as ___Earners___. ___Earners___ may be awarded badges directly, or through assessment processes involving submission of evidence - the nature of the issuing process is determined by the ___Issuer___.
+
+The people and organizations who award Open Badges are referred to as ___Issuers___. Issuing is the technical act of awarding a badge, the implementation of which is creating a ___Badge Assertion___.
+
+___Displayers___ of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. ___Displayers___ therefore deal with the data in ___Badge Assertions___, which is created by ___Issuers___. Prior to display, Open Badges can be collected using software tools, some of which are referred to as ___Backpacks___. ___Displayers___ may retrieve the data describing an ___Earner's___ badges from a ___Backpack___. The ___Earner___ should have full control over which badges are publicly visible.
+
+For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. ___Issuers___ are responsible for including the information necessary for this verification, while ___Displayers___ are responsible for using it to check that a badge was awarded by an ___Issuer___, to an ___Earner___. 
+
 ## Terminology
 
 The Open Badges Assertion specification uses the following terms as defined:
@@ -87,17 +100,17 @@ A JSON-structured representation of a badge awarded to an Earner. An Assertion d
 <a name="term-assessment"></a>
 __Assessment__
 
-In some badging systems, Earner [evidence](#term-evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the Badge Assertion.
+In some badging systems, Earner [evidence](#term-evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the [Badge Assertion](#term-badge-assertion).
 
 <a name="term-award"></a>
 __Award__
 
-In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#term-issue) it - this involves the badge [Issuer](#term-issuer) creating a Badge Assertion to describe the award.
+In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#term-issue) it - this involves the badge [Issuer](#term-issuer) creating a [Badge Assertion](#term-badge-assertion) to describe the award.
 
 <a name="term-backpack"></a>
 __Backpack__
 
-A Backpack is a software tool through which [Earners](#term-earner) can collect Open Badges they have been awarded. Typically a Backpack allows the Earner to control visibility of their badges. [Displayers](#term-displayer) may connect to Backpacks to retrieve the data about badges associated with an Earner.
+A Backpack is a software tool through which [Earners](#term-earner) can collect Open Badges they have been awarded. Typically a Backpack allows the Earner to control visibility of their badges. [Displayers](#term-displayer) can connect to Backpacks to retrieve the data about badges associated with an Earner.
 
 <a name="term-badge"></a>
 __Badge__
@@ -107,22 +120,22 @@ In the context of the OBI, a badge is loosely described as a digital representat
 <a name="term-badge-class"></a>
 __Badge Class__
 
-The Badge Class forms part of an Open Badge Assertion. The Badge Class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A Badge Class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the Badge Assertion for each award of the badge. The Badge Class file __should__ include a link to the [Issuer Organization](#term-issuer-organization).
+The Badge Class forms part of an Open Badge Assertion. The Badge Class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A Badge Class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the [Badge Assertion](#term-badge-assertion) for each award of the badge described. The Badge Class file __must__ include a link to the [Issuer Organization](#term-issuer-organization).
 
 <a name="term-bake"></a>
 __Bake, Baking, Baked Badge__
 
-A baked badge is a badge image file with the data for an Assertion embedded into it. The image __may__ be a PNG or SVG file. Baking badges makes them more portable, allowing Earners to communicate and display them wherever they choose. Software can extract the Assertion from a baked badge to provide access to the metadata describing the award.
+A baked badge is a badge image file with the data for an Assertion embedded into it. The image __must__ be either a PNG or SVG file. Baked badges are more portable, allowing [Earners](#term-earner) to communicate and display them wherever they choose. Software can extract the Assertion data from a baked badge to access the metadata describing the award.
 
 <a name="term-criteria"></a>
 __Criteria__
 
-A definition of the requirements for earning a badge. The criteria for a badge are included in the [Badge Class](#term-badge-class) as a URL.
+A definition of the requirements for earning a badge. The criteria for a badge __must__ be included in the [Badge Class](#term-badge-class) as a URL.
 
 <a name="term-displayer"></a>
 __Displayer__
 
-A badge Displayer presents information about public badge awards in a digital context. Badge Earners can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
+A badge Displayer presents information about public badge awards in a digital context. Badge [Earners](#term-earner) can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
 
 <a name="term-earner"></a>
 __Earner__
@@ -183,26 +196,6 @@ Validation is the act of checking a Badge Assertion for structural validity. Thi
 __Verify, Verification__
 
 Verification is the act of checking that a badge was awarded by the Issuer to the Earner. Badge Displayers __should__ carry out verification on badges before displaying them. Badge Issuers __should__ include the information necessary for this verification to be implemented. Verification should be tailored to whether a Badge Assertion is [___signed___](#term-signed-badge) or [___hosted___](#term-hosted-badge).
-
-<!-- 
-* _internet terms http://tools.ietf.org/html/rfc1983_
-* _concise sections and more detailed sections http://tools.ietf.org/html/rfc2360#section-2.4_
-* _concise sections could be badge assertion, badge class etc (brief but with some description), summary tables (v concise), then more detail in implementation sections - primitive types?_
--->
-
-## Concepts
-
-Adopting the OBI involves understanding a range of concepts which refer to existing and well-known real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
-
-An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to Earners. The generic badge is defined using a __Badge Class__, while an awarded badge is defined using a __Badge Assertion__. In this sense, a generic badge can be conceptualized as the template for awarded badges. This connection is implemented by including a link to a __Badge Class__ in each __Badge Assertion__.
-
-People who are awarded Open Badges are referred to as __Earners__. __Earners__ may be awarded badges directly, or through assessment processes involving submission of evidence - the nature of the issuing process is determined by the Issuer.
-
-The people and organizations who award Open Badges are referred to as __Issuers__. Issuing is the technical act of awarding a badge, the implementation of which is creating a __Badge Assertion__.
-
-__Displayers__ of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. __Displayers__ therefore deal with the data in __Badge Assertions__, which is created by __Issuers__. Prior to display, Open Badges can be collected using software tools - some of these referred to as __Backpacks__. __Displayers__ may retrieve the data describing an __Earner's__ badges from a __Backpack__. The __Earner__ __should__ have full control over which badges are publicly visible.
-
-For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. __Issuers__ __should__ include the information necessary for this verification, while __Displayers__ __should__ use it to check that a badge was awarded by an __Issuer__, to an __Earner__. 
 
 ## Data Model
 
@@ -672,8 +665,6 @@ To revoke ___hosted___ badges, Issuers __should__ respond to requests on the rev
 
 To revoke ___signed___ badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with the Badge Assertion `uid`s as keys and the reason for revocation as values. The revocation list JSON URL __should__ be included in the Issuer Organization `revocatonList` field.
 
-<!--setting content type examples move to sep doc?-->
-
 ## Displayer Implementations
 
 Open Badge Displayers __should__ carry out verification steps prior to presenting awarded badges for output in digital contexts.
@@ -735,7 +726,8 @@ https://github.com/mozilla/openbadges-validator/
 
 ___To follow___
 
-<!--explain working groups etc, in particular explain contentious decisions, "why" as well as "how"-->
+<!--explain working groups etc, in particular explain contentious decisions, "why" as well as "how"
+http://tools.ietf.org/html/rfc2360#section-2.7-->
 
 ## References
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -57,106 +57,107 @@ The Open Badges Assertion specification relies on JSON syntax, some knowledge of
 The Open Badges Assertion specification uses the following terms as defined:
 
 <a name="term-badge-assertion"><a>
-### Badge Assertion
+__Badge Assertion__
 
 A JSON-structured representation of a badge awarded to an earner. An Assertion describes the badge [earner](#term-earner), what the badge represents and the [issuer](#term-issuer). The data items within an Assertion include: a unique ID; the earner (recipient) identity; details of the [badge class](#term-badge-class) (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [hosted](#term-hosted-badge) or [signed](#term-signed-badge).
 
 <a name="term-assessment"></a>
-### Assessment
+__Assessment__
 
 In some badging systems, earner [evidence](#term-evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the Assertion.
 
 <a name="term-award"></a>
-### Award
+__Award__
 
 In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#term-issue) it - this involves the badge [issuer](#term-issuer) creating an Assertion to describe the award.
 
 <a name="term-backpack"></a>
-### Backpack
+__Backpack__
 
 A Backpack is a software tool through which [earners](#term-earner) can collect Open Badges they have been awarded. Typically a Backpack allows the earner to control visibility of their badges. [Displayers](#term-displayer) may connect to Backpacks to retrieve the data about badges associated with an earner.
 
 <a name="term-badge"></a>
-### Badge
+__Badge__
 
 In the context of the OBI, a badge is loosely described as a digital representation of a skill, learning achievement or experience. A badge is represented in digital contexts as an image and some metadata. For the badge to exist within the OBI, this metadata must conform to the Assertion specification.
 
 <a name="term-badge-class"></a>
-### Badge Class
+__Badge Class__
 
 The badge class forms part of an Open Badge Assertion. The badge class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A badge class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the badge Assertion for each award of the badge. The badge class file should include a link to the [issuer organization](#term-issuer-organization).
 
 <a name="term-bake"></a>
-### Bake, Baking, Baked Badge
+__Bake, Baking, Baked Badge__
 
 A baked badge is a badge image file with the data for an Assertion embedded into it. The image may be a PNG or SVG file. Baking badges makes them more portable, allowing earners to communicate and display them wherever they choose. Software can extract the Assertion from a baked badge to provide access to the metadata describing the award.
 
 <a name="term-criteria"></a>
-### Criteria
+__Criteria__
 
 A definition of the requirements for earning a badge. The criteria for a badge are included in the [badge class](#term-badge-class) as a URL.
 
 <a name="term-displayer"></a>
-### Displayer
+__Displayer__
 
 A badge displayer presents information about public badge awards in a digital context. Badge earners can add their awarded badges to public collections, which displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge displayers should [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the earner claiming it.
 
 <a name="term-earner"></a>
-### Earner
+__Earner__
 
 An earner is someone who has been awarded one or more Open Badges. Depending on the badging system, the earner may apply for a badge, supplying supporting evidence. When an issuer awards a badge, they build information about the earner identity into a new badge Assertion.
 
 <a name="term-evidence"></a>
-### Evidence
+__Evidence__
 
 A badge Assertion may include a URL representing evidence for the badge award. Depending on the badging system, the earner may have submitted this evidence as part of an application process. Typically, the issuer would compared the evidence to the badge [criteria](#term-criteria) in order to make an awarding decision.
 
 <a name="term-hosted-badge"></a>
-### Hosted Badge
+__Hosted Badge__
 
 A hosted badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a hosted badge are: the [assertion](#term-badge-assertion); the [badge class](#term-badge-class); the [issuer organization](#term-issuer-organization). The badge Assertion includes a [verification](#term-verify) field in which either a hosted or [signed](#term-signed-badge) type is specified.
 
 <a name="term-issue"></a>
-### Issue
+__Issue__
 
 Issuing is the act of awarding a badge to an earner. Typically badge [issuers](#term-issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an issuer must create a [Badge Assertion](#term-badge-assertion), which may be [hosted](#term-hosted-badge) or [signed](#term-signed-badge).
 
 <a name="term-issuer"></a>
-### Issuer
+__Issuer__
 
 An issuer is a person or organization (or department within an organization) who/ which awards Open Badges to earners. Typically the issuer is responsible for designing and creating the badge as well as awarding it. The issuer may choose to implement various optional processes in a badging system, such as [assessment](#term-assessment).
 
 <a name="term-issuer-organization"></a>
-### Issuer Organization
+__Issuer Organization__
 
 The issuer organization is the part of an Open Badge Assertion in which the badge issuer is described. The issuer organization must be included in the [badge class](#term-badge-class) by URL. The URL must return a JSON representation of the issuer, in which fields specify the issuer name and URL, as well as other optional descriptive properties. Typically the issuer organization data will be used to [verify](#term-verify) awarded badges.
 
 <a name="term-metadata"></a>
-### Metadata
+__Metadata__
 
 In the OBI, metadata is information about badges, badge awards and badge issuers. OBI metadata is defined in JSON as part of the Assertion specification.
 
-### Open Badge Infrastructure (OBI)
+<a name="term-obi"></a>
+__Open Badge Infrastructure (OBI)__
 
 The OBI is a set of software tools and specifications to support Open Badge systems. These tools provide a framework for issuing, displaying and earning Open Badges within an open ecosystem.
 
 <a name="term-revoke"></a>
-### Revoke
+__Revoke__
 
 Badge issuers can revoke badges they awarded to earners. In such cases, the [issuer organization](#term-issuer-organization) should include a list of signed badges that have been revoked, and/or provide a revocation response to requests at the original badge assertion URL. Badge displayers should not display revoked badges and should check revocation status during [verification](#term-verify).
 
 <a name="term-signed-badge"></a>
-### Signed Badge
+__Signed Badge__
 
 A signed badge has its Assertion data included in a JSON Web Signature (JWS). Typically a signed badge still uses hosted JSON files for the [badge class](#term-badge-class) and [issuer organization](#term-issuer-organization), but the [badge assertion](#term-badge-assertion) JSON is itself packaged as a signature. The badge Assertion includes a [verification](#term-verify) field in which either a hosted or [signed](#term-signed-badge) type is specified.
 
 <a name="term-validate"></a>
-### Validate, Validation, Validator
+__Validate, Validation, Validator__
 
 Validation is the act of checking a badge assertion for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any resources linked within the assertion are available.
 
 <a name="term-verify"></a>
-### Verify, Verification
+__Verify, Verification__
 
 Verification is the act of checking that a badge was awarded by the issuer to the earner. Badge displayers should carry out verification on badges before displaying them. Badge issuers should include the information necessary for this verification to be implemented. Verification must be tailored to whether a badge assertion is [signed](#term-signed-badge) or [hosted](#term-hosted-badge).
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -651,17 +651,17 @@ Discussions regarding extensions to the Open Badge structures can be found here:
 
 ## Issuer Implementations
 
-Typically a badge Issuer is responsible for creating the three parts of an Open Badge, as well as deciding who to award badges to. The Issuer __may__ use a single Issuer Organization file for all of the badges they issue. Each Issuer Organization may be included in the `issuer` field for multiple Badge Classes. In turn, each Badge Class may be included in the `badge` field for multiple Badge Assertions.
+Typically a badge Issuer is responsible for creating the three parts of an Open Badge, as well as deciding who to award badges to. The Issuer __may__ use a single Issuer Organization file for all of the badges they issue. Each Issuer Organization URL may therefore be included in the `issuer` field for multiple Badge Classes. In turn, each Badge Class URL may be included in the `badge` field for multiple Badge Assertions.
 
-The Issuer __must__ host JSON resources at publicly accessible stable locations, with the content-type set to `application/json`. Any resources linked from the Open Badge JSON files __should__ also be at stable URLs.
+The Issuer __must__ host JSON resources at publicly accessible stable locations, with the content-type set to `application/json`. Any resources linked from the Open Badge JSON files __should__ also be at stable URLs. If linked resources are not available, a badge will be considered invalid.
 
-Where ___signed___ badges are used, the Issuer __must__ also host the public key (corresponding to the private key used for signing) at a stable URL. 
+Where ___signed___ badges are used, the Issuer __must__ also host the public key (corresponding to the private key used for signing) at a stable URL. This URL __must__ be included in the `verify.url` field of the Badge Assertion.
 
 ### Badge Revocation
 
 To revoke ___hosted___ badges, Issuers __should__ respond to requests on the revoked Badge Assertions with an HTTP Status of `410 Gone` and a body of `{ "revoked":true }`.
 
-To revoke ___signed___ badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with the Badge Assertion `uid` as keys and the reason for revocation as values. The revocation list JSON URL __should__ be included in the Issuer Organization `revocationList` field.
+To revoke ___signed___ badges, the Issuer __should__ host a revocation list JSON file indicating the badges they have revoked, with each revoked Badge Assertion `uid` as keys and the reasons for revocation as values. The revocation list JSON URL __should__ be included in the Issuer Organization `revocationList` field.
 
 ## Displayer Implementations
 
@@ -694,19 +694,19 @@ To verify a ___signed___ badge, Displayers __should__:
 <a name="assert-structural-validity"></a>
 To assert structural validity, Displayers __should__ ensure the following badge properties:
 
-* `badge`: __must__ be a valid **URL**. An HTTP GET request __must__ be performed on the URL to ensure eventual 200 OK status.
-* `recipient`: __must__ be an object
-	* `type`: __must__ be a valid type (currently only "email" is supported)
-	* `identity`: __must__ be ***text***
-	* `hashed` (_optional_): __must__ be ***boolean***
-	* `salt` (_optional_): __must__ be ***text***
-* `image` (_optional_): __must__ be a valid ***URL*** or ***Data URL***
-* `evidence` (_optional_): __must__ be a valid ***URL***
-* `issuedOn` (_optional_): __must__ be a valid ***DateTime***
-* `expires` (_optional_): __must__ be a valid ***DateTime***
-* `verify`: __must__ be an object
-	* `type`: __must__ be either "hosted" or "signed"
-	* `url`: __must__ be a ***URL***
+* `badge`: __Must__ be a valid **URL**. _An HTTP GET request must be performed on the URL to ensure eventual 200 OK status._
+* `recipient`: __Must__ be an object
+	* `type`: __Must__ be a valid type (currently only "email" is supported)
+	* `identity`: __Must__ be ***text***
+	* `hashed` (_optional_): __Must__ be ***boolean***
+	* `salt` (_optional_): __Must__ be ***text***
+* `image` (_optional_): __Must__ be a valid ***URL*** or ***Data URL***
+* `evidence` (_optional_): __Must__ be a valid ***URL***
+* `issuedOn` (_optional_): __Must__ be a valid ***DateTime***
+* `expires` (_optional_): __Must__ be a valid ***DateTime***
+* `verify`: __Must__ be an object
+	* `type`: __Must__ be either "hosted" or "signed"
+	* `url`: __Must__ be a ***URL***
 
 Displayers __should__ also check that the recipient email address matches the address of the person claiming the badge. This may involve hashing the claimed email (using the `salt` value from the `recipient` object if supplied) and comparing it to the `identity` field in the `recipient` object.
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -24,7 +24,7 @@ This typically includes descriptive information about the achievement, an image 
 * criteria for earning the badge
 * verification details for the earner identity and badge award
 
-The Assertion specification defines a series of required and optional data fields to fulfill the above aims. Assertions may also include optional information such as evidence, educational standards alignment details and an expiry date.
+The Assertion specification defines a series of required and optional properties to fulfill the above aims. Assertions may also include optional information such as evidence, educational standards alignment details and an expiry date.
 
 The purpose of the Assertion specification is to provide a reference for all implementers of Open Badge systems. This primarily means badge issuers and displayers.
 
@@ -56,66 +56,82 @@ The Open Badges Assertion specification relies on JSON syntax, some knowledge of
 
 The Open Badges Assertion specification uses the following terms as defined:
 
-### Assertion
+<a name="term-badge-assertion"><a>
+### Badge Assertion
 
-A JSON-structured representation of a badge awarded to an earner. An Assertion describes the badge [earner](#earner), what the badge represents and the [issuer](#issuer). The data items within an Assertion include: a unique ID; the earner (recipient) identity; details of the [badge class](#badge-class) (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [hosted](#hosted-badge) or [signed](#signed-badge).
+A JSON-structured representation of a badge awarded to an earner. An Assertion describes the badge [earner](#term-earner), what the badge represents and the [issuer](#term-issuer). The data items within an Assertion include: a unique ID; the earner (recipient) identity; details of the [badge class](#term-badge-class) (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [hosted](#term-hosted-badge) or [signed](#term-signed-badge).
 
+<a name="term-assessment"></a>
 ### Assessment
 
-In some badging systems, earner [evidence](#evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the Assertion.
+In some badging systems, earner [evidence](#term-evidence) is assessed as part of the awarding decision. In such cases, details of the evidence can be included in the Assertion.
 
+<a name="term-award"></a>
 ### Award
 
-In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#issue) it - this involves the badge [issuer](#issuer) creating an Assertion to describe the award.
+In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#term-issue) it - this involves the badge [issuer](#term-issuer) creating an Assertion to describe the award.
 
+<a name="term-backpack"></a>
 ### Backpack
 
-A Backpack is a software tool through which [earners](#earner) can collect Open Badges they have been awarded. Typically a Backpack allows the earner to control visibility of their badges. [Displayers](#displayer) may connect to Backpacks to retrieve the data about badges associated with an earner.
+A Backpack is a software tool through which [earners](#term-earner) can collect Open Badges they have been awarded. Typically a Backpack allows the earner to control visibility of their badges. [Displayers](#term-displayer) may connect to Backpacks to retrieve the data about badges associated with an earner.
 
+<a name="term-badge"></a>
 ### Badge
 
 In the context of the OBI, a badge is loosely described as a digital representation of a skill, learning achievement or experience. A badge is represented in digital contexts as an image and some metadata. For the badge to exist within the OBI, this metadata must conform to the Assertion specification.
 
+<a name="term-badge-class"></a>
 ### Badge Class
 
-The badge class forms part of an Open Badge Assertion. The badge class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A badge class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the badge Assertion for each award of the badge. The badge class file should include a link to the [issuer organization](#issuer-organization).
+The badge class forms part of an Open Badge Assertion. The badge class describes the badge name, what it represents, the criteria for earning it, the image used to display it, the issuing organization and optionally educational standards it aligns to. A badge class should typically be hosted in a JSON file at a stable URL, with a link to this file included in the badge Assertion for each award of the badge. The badge class file should include a link to the [issuer organization](#term-issuer-organization).
 
+<a name="term-bake"></a>
 ### Bake, Baking, Baked Badge
 
 A baked badge is a badge image file with the data for an Assertion embedded into it. The image may be a PNG or SVG file. Baking badges makes them more portable, allowing earners to communicate and display them wherever they choose. Software can extract the Assertion from a baked badge to provide access to the metadata describing the award.
 
+<a name="term-criteria"></a>
 ### Criteria
 
-A definition of the requirements for earning a badge. The criteria for a badge are included in the [badge class](#badge-class) as a URL.
+A definition of the requirements for earning a badge. The criteria for a badge are included in the [badge class](#term-badge-class) as a URL.
 
+<a name="term-displayer"></a>
 ### Displayer
 
-A badge displayer presents information about public badge awards in a digital context. Badge earners can add their awarded badges to public collections, which displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge displayers should [verify](#verify-verification) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the earner claiming it.
+A badge displayer presents information about public badge awards in a digital context. Badge earners can add their awarded badges to public collections, which displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge displayers need an understanding of the Assertion structure in order to extract and display the relevant data. Badge displayers should [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the earner claiming it.
 
+<a name="term-earner"></a>
 ### Earner
 
 An earner is someone who has been awarded one or more Open Badges. Depending on the badging system, the earner may apply for a badge, supplying supporting evidence. When an issuer awards a badge, they build information about the earner identity into a new badge Assertion.
 
+<a name="term-evidence"></a>
 ### Evidence
 
-A badge Assertion may include a URL representing evidence for the badge award. Depending on the badging system, the earner may have submitted this evidence as part of an application process. Typically, the issuer would compared the evidence to the badge [criteria](#criteria) in order to make an awarding decision.
+A badge Assertion may include a URL representing evidence for the badge award. Depending on the badging system, the earner may have submitted this evidence as part of an application process. Typically, the issuer would compared the evidence to the badge [criteria](#term-criteria) in order to make an awarding decision.
 
+<a name="term-hosted-badge"></a>
 ### Hosted Badge
 
-A hosted badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a hosted badge are: the [assertion](#assertion); the [badge class](#badge-class); the [issuer organization](#issuer-organization). The badge Assertion includes a [verification](#verify-verification) field in which either a hosted or [signed](#signed-badge) type is specified.
+A hosted badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a hosted badge are: the [assertion](#term-badge-assertion); the [badge class](#term-badge-class); the [issuer organization](#term-issuer-organization). The badge Assertion includes a [verification](#term-verify) field in which either a hosted or [signed](#term-signed-badge) type is specified.
 
+<a name="term-issue"></a>
 ### Issue
 
-Issuing is the act of awarding a badge to an earner. Typically badge [issuers](#issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an issuer must create a badge [Assertion](#assertion), which may be [hosted](#hosted-badge) or [signed](#signed-badge).
+Issuing is the act of awarding a badge to an earner. Typically badge [issuers](#term-issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an issuer must create a [Badge Assertion](#term-badge-assertion), which may be [hosted](#term-hosted-badge) or [signed](#term-signed-badge).
 
+<a name="term-issuer"></a>
 ### Issuer
 
-An issuer is a person or organization (or department within an organization) who/ which awards Open Badges to earners. Typically the issuer is responsible for designing and creating the badge as well as awarding it. The issuer may choose to implement various optional processes in a badging system, such as [assessment](#assessment).
+An issuer is a person or organization (or department within an organization) who/ which awards Open Badges to earners. Typically the issuer is responsible for designing and creating the badge as well as awarding it. The issuer may choose to implement various optional processes in a badging system, such as [assessment](#term-assessment).
 
+<a name="term-issuer-organization"></a>
 ### Issuer Organization
 
-The issuer organization is the part of an Open Badge Assertion in which the badge issuer is described. The issuer organization must be included in the [badge class](#badge-class) by URL. The URL must return a JSON representation of the issuer, in which fields specify the issuer name and URL, as well as other optional descriptive fields. Typically the issuer organization data will be used to [verify](#verify-verification) awarded badges.
+The issuer organization is the part of an Open Badge Assertion in which the badge issuer is described. The issuer organization must be included in the [badge class](#term-badge-class) by URL. The URL must return a JSON representation of the issuer, in which fields specify the issuer name and URL, as well as other optional descriptive properties. Typically the issuer organization data will be used to [verify](#term-verify) awarded badges.
 
+<a name="term-metadata"></a>
 ### Metadata
 
 In the OBI, metadata is information about badges, badge awards and badge issuers. OBI metadata is defined in JSON as part of the Assertion specification.
@@ -124,21 +140,25 @@ In the OBI, metadata is information about badges, badge awards and badge issuers
 
 The OBI is a set of software tools and specifications to support Open Badge systems. These tools provide a framework for issuing, displaying and earning Open Badges within an open ecosystem.
 
+<a name="term-revoke"></a>
 ### Revoke
 
-Badge issuers can revoke badges they awarded to earners. In such cases, the [issuer organization](#issuer-organization) should include a list of signed badges that have been revoked, and/or provide a revocation response to requests at the original badge assertion URL. Badge displayers should not display revoked badges and should check revocation status during [verification](#verify-verification).
+Badge issuers can revoke badges they awarded to earners. In such cases, the [issuer organization](#term-issuer-organization) should include a list of signed badges that have been revoked, and/or provide a revocation response to requests at the original badge assertion URL. Badge displayers should not display revoked badges and should check revocation status during [verification](#term-verify).
 
+<a name="term-signed-badge"></a>
 ### Signed Badge
 
-A signed badge has its Assertion data included in a JSON Web Signature (JWS). Typically a signed badge still uses hosted JSON files for the [badge class](#badge-class) and [issuer organization](#issuer-organization), but the [assertion](#assertion) JSON is itself packaged as a signature. The badge Assertion includes a [verification](#verify-verification) field in which either a hosted or [signed](#signed-badge) type is specified.
+A signed badge has its Assertion data included in a JSON Web Signature (JWS). Typically a signed badge still uses hosted JSON files for the [badge class](#term-badge-class) and [issuer organization](#term-issuer-organization), but the [badge assertion](#term-badge-assertion) JSON is itself packaged as a signature. The badge Assertion includes a [verification](#term-verify) field in which either a hosted or [signed](#term-signed-badge) type is specified.
 
+<a name="term-validate"></a>
 ### Validate, Validation, Validator
 
 Validation is the act of checking a badge assertion for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any resources linked within the assertion are available.
 
+<a name="term-verify"></a>
 ### Verify, Verification
 
-Verification is the act of checking that a badge was awarded by the issuer to the earner. Badge displayers should carry out verification on badges before displaying them. Badge issuers should include the information necessary for this verification to be implemented. Verification must be tailored to whether a badge assertion is [signed](#signed-badge) or [hosted](#hosted-badge).
+Verification is the act of checking that a badge was awarded by the issuer to the earner. Badge displayers should carry out verification on badges before displaying them. Badge issuers should include the information necessary for this verification to be implemented. Verification must be tailored to whether a badge assertion is [signed](#term-signed-badge) or [hosted](#term-hosted-badge).
 
 <!-- 
 * _internet terms http://tools.ietf.org/html/rfc1983_
@@ -148,24 +168,89 @@ Verification is the act of checking that a badge was awarded by the issuer to th
 
 ## Concepts
 
-Adopting the OBI involves understanding a range of concepts which refer to real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
+Adopting the OBI involves understanding a range of concepts which refer to existing and well-known real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
 
-An Open Badge is a digital representation of a skill or achievement, which is communicated using JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to earners. The generic badge is defined using a Badge Class, while an awarded badge is defined using a Badge Assertion. In this sense, the generic badge can be conceptualized as the template for the awarded badges. This connection is present in the implementation of an awarded badge by including a link to the Badge Class in the Badge Assertion.
+An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. In terms of implementation, there are two types of badge: generic badges which are "earnable" and badges which have actually been awarded to earners. The generic badge is defined using a Badge Class, while an awarded badge is defined using a Badge Assertion. In this sense, a generic badge can be conceptualized as the template for awarded badges. This connection is implementated by including a link to a Badge Class in each Badge Assertion.
 
 People who are awarded Open Badges are referred to as Earners. Earners may be awarded badges directly, or through assessment processes involving submission of evidence - the nature of the issuing process is determined by the Issuer.
 
 The people and organizations who award Open Badges are referred to as Issuers. Issuing is the technical act of awarding a badge, the implementation of which is creating a Badge Assertion.
 
-Displayers of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. Displayers therefore deal with the data in Badge Assertions, which is created by Issuers. Prior to display, Open Badges can be collected using software tools - these may be referred to as Backpacks. Displayers may retrieve the data describing an earner's badges from a Backpack. The earner should have full control over which badges are publicly visible.
+Displayers of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. Displayers therefore deal with the data in Badge Assertions, which is created by Issuers. Prior to display, Open Badges can be collected using software tools - some of these referred to as Backpacks. Displayers may retrieve the data describing an Earner's badges from a Backpack. The Earner should have full control over which badges are publicly visible.
 
 For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. Issuers should include the information necessary for this verification, while Displayers should use it to check that a badge was awarded by an Issuer, to an Earner. 
 
 ## Data Model
 
+Open Badges define their structures in JSON. Three JSON files make up an awarded badge: 
+
+* Badge Assertion
+* Badge Class
+* Issuer Organization
+
+These three include JSON objects, arrays and values. The Badge Assertion includes a field for the URL of the Badge Class, while the Badge Class includes a link to the Issuer Organization.
+
+* A Badge Assertion can be associated with one Badge Class.
+* A Badge Class can be associated with one or more Badge Assertions.
+* A Badge Class can be associated with one Issuer Organization
+* An Issuer Organization can be associated with one or more Badge Classes.
+
+As is outlined in the below sections, the values in the Open Badges JSON files include primitive types such as text string, boolean, DateTime and URL, as well as objects and arrays including nested values.
+
+_Proposals to extend the JSON structures are currently under discussion: https://github.com/mozilla/openbadges-discussion/issues/20_
+
+<a name="badge-assertion"></a>
 ### Badge Assertion
 
+A Badge Assertion is a JSON file or JSON Web Signature (JWS) describing an Open Badge awarded to an Earner.
+
+#### Properties
+
+A Badge Assertion may include the following required and optional properties:
+
+<a name="uid"></a>
+* `uid : "<text>"` __required__
+
+Unique Identifier for the badge assertion. This should be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
+
+<a name="recipient"></a>
+* `recipient : `[`IdentityObject`](#identity-object) __required__
+
+Definition of Earner identity.
+
+<a name="assertion-badge"></a>
+* `badge : "<url>"` __required__
+
+URL of the [Badge Class](#badge-class) describing the badge awarded.
+
+##### `IdentityObject`
+
+Defines the identity of the Earner awarded this badge using the following properties:
+
+<a name="identity"></a>
+* `identity : "<text>"` __required__
+
+Plain text or hash of identity value. If it's possible that the plain text transmission and storage of the identity value would leak personally identifiable information, an hash should be used. Hash string should be preceded by a dollar sign (`$`) and the algorithm used to generate the hash.
+
+<a name="identity-type"></a>
+* `type : "<text>"` __required__
+
+The type of identity value - __currently only "email" is supported__.
+
+<a name="hashed"></a>
+* `hashed : "<boolean>"` __required__
+
+Boolean indicator of whether or not the `identity` value is hashed.
+
+<a name="salt"></a>
+* `salt : "<text>"` _optional_
+
+Hashed `identity` values may be salted. If the recipient is hashed, `salt` should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
+
+<a name="badge-class"></a>
 ### Badge Class
 
+<a name="issuer-organization"></a>
 ### Issuer Organization
 
 #### Summary Tables

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -29,69 +29,71 @@ Fields marked **in bold letters** are mandatory.
 
 #### BadgeAssertion
 
-| Property | Expected Type | Description |
-| -------- | ------------- | ----------- |
-| **uid** | Text | Unique Identifier for the badge. This is expected to be **locally** unique on a per-origin basis, not globally unique. |
-| **recipient** | [IdentityObject](#identityobject) | The recipient of the achievement. |
-| **badge** | URL | URL that describes the type of badge being awarded. The endpoint should be a [BadgeClass](#badgeclass) |
-| **verify** | [VerificationObject](#verificationobject) | Data to help a third party verify this assertion. |
-| **issuedOn** | [DateTime](#primitives) | Date that the achievement was awarded. |
-| image | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing this achievement. This must be a PNG image, and if possible, the image should be prepared via the [Baking specification](https://github.com/mozilla/openbadges-specification/blob/master/Badge-Baking/latest.md). |
-| evidence | URL | URL of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. |
-| expires | [DateTime](#primitives) | If the achievment has some notion of expiry, this indicates when a badge should no longer be considered valid. |
+| Property | Status | Expected Type | Description |
+| -------- | -------- | ------------- | ----------- |
+| **uid** | **required** | Text | Unique Identifier for the badge. This is expected to be **locally** unique on a per-origin basis, not globally unique. |
+| **recipient** | **required** | [IdentityObject](#identityobject) | The recipient of the achievement. |
+| **badge** | **required** | URL | URL that describes the type of badge being awarded. The endpoint should be a [BadgeClass](#badgeclass) |
+| **verify** | **required** | [VerificationObject](#verificationobject) | Data to help a third party verify this assertion. |
+| **issuedOn** | **required** | [DateTime](#primitives) | Date that the achievement was awarded. |
+| image | _optional_ | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing this achievement. This must be a PNG image, and if possible, the image should be prepared via the [Baking specification](https://github.com/mozilla/openbadges-specification/blob/master/Badge-Baking/latest.md). |
+| evidence | _optional_ | URL | URL of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. |
+| expires | _optional_ | [DateTime](#primitives) | If the achievment has some notion of expiry, this indicates when a badge should no longer be considered valid. |
 
 
 #### <a id="identity-object"></a>IdentityObject
 
-Property | Expected Type | Description
---------|------------|-----------
-**identity** | [IdentityHash](#primitives) or Text | Either the hash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information, it is strongly recommended that an IdentityHash be used.
-**type** | [IdentityType](#primitives) | The type of identity.
-**hashed** | Boolean | Whether or not the `id` value is hashed.
-salt | Text | If the recipient is hashed, this should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
+| Property | Status | Expected Type | Description |
+|--------|--------|------------|-----------|
+|**identity** | **required** | [IdentityHash](#primitives) or Text | Either the hash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information, it is strongly recommended that an IdentityHash be used.|
+|**type** | **required** | [IdentityType](#primitives) | The type of identity.|
+|**hashed** | **required** | Boolean | Whether or not the `id` value is hashed.|
+|salt | _optional_ | Text | If the recipient is hashed, this should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.|
 
 
 #### <a id="verification-object"></a>VerificationObject
 
-Property | Expected Type | Description
---------|------------|-----------
-**type** | VerificationType | The type of verification method.
-**url** | URL | If the type is "hosted", this should be a URL pointing to the assertion on the issuer's server. If the type is "signed", this should be a link to the issuer's public key.
+| Property | Status | Expected Type | Description |
+|--------|--------|------------|-----------|
+|**type** | **required** | VerificationType | The type of verification method.|
+|**url** | **required** | URL | If the type is "hosted", this should be a URL pointing to the assertion on the issuer's server. If the type is "signed", this should be a link to the issuer's public key.|
 
 
 
 #### <a id="badge-class"></a>BadgeClass
 
-Property | Expected Type | Description
---------|------------|-----------
-**name** | Text | The name of the achievement.
-**description** | Text | A short description of the achievement.
-**image** | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing the achievement.
-**criteria** | URL | URL of the criteria for earning the achievement. If the badge represents an educational achievement, consider marking up this up with [LRMI](http://www.lrmi.net/)
-**issuer** | URL | URL of the organization that issued the badge. Endpoint should be an [IssuerOrganization](#issuerorganization)
-alignment | Array of [AlignmentObjects](#alignmentobject) | List of objects describing which educational standards this badge aligns to, if any.
-tags | Array of Text | List of tags that describe the type of achievement.
+| Property | Status | Expected Type | Description |
+|--------|--------|------------|-----------|
+|**name** | **required** | Text | The name of the achievement.|
+|**description** | **required** | Text | A short description of the achievement.|
+|**image** | **required** | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | URL of an image representing the achievement.|
+|**criteria** | **required** | URL | URL of the criteria for earning the achievement. If the badge represents an educational achievement, consider marking up this up with [LRMI](http://www.lrmi.net/)|
+|**issuer** | **required** | URL | URL of the organization that issued the badge. Endpoint should be an [IssuerOrganization](#issuerorganization)|
+|alignment | _optional_ | Array of [AlignmentObjects](#alignmentobject) | List of objects describing which educational standards this badge aligns to, if any.|
+|tags | _optional_ | Array of Text | List of tags that describe the type of achievement.|
 
 
-#### <a id="alignment-object"></a>AlignmentObject
+#### <a id="alignment-object"></a>AlignmentObject 
 
-Property | Expected Type | Description
---------|------------|-----------
-**name** | Text | Name of the alignment.
-**url** | URL | URL linking to the official description of the standard.
-description | Text | Short description of the standard
+_AlignmentObject is optional - fields below are required **if** it is included in the BadgeClass._
+
+| Property | Status | Expected Type | Description|
+|--------|--------|------------|-----------|
+|**name** | **required** | Text | Name of the alignment.|
+|**url** | **required** | URL | URL linking to the official description of the standard.|
+|description | _optional_ | Text | Short description of the standard.|
 
 
 #### <a id="issuer-organization"></a>IssuerOrganization
 
-Property | Expected Type | Description
---------|------------|-----------
-**name** | Text | The name of the issuing organization.
-**url** | URL | URL of the institution
-description | Text | A short description of the institution
-image | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | An image representing the institution
-email | Text | Contact address for someone at the organization.
-revocationList | URL |  URL of the Badge Revocation List. The endpoint should be a JSON representation of an object where the keys are the **uid** a revoked badge assertion, and the values are the reason for revocation. This is only necessary for signed badges.
+| Property | Status | Expected Type | Description |
+|--------|--------|------------|-----------|
+|**name** | **required** | Text | The name of the issuing organization.|
+|**url** | **required** | URL | URL of the institution.|
+|description | _optional_ | Text | A short description of the institution.|
+|image | _optional_ | [Data URL](http://en.wikipedia.org/wiki/Data_URI_scheme) or URL | An image representing the institution.|
+|email | _optional_ | Text | Contact address for someone at the organization.|
+|revocationList | _optional_ | URL |  URL of the Badge Revocation List. The endpoint should be a JSON representation of an object where the keys are the **uid** a revoked badge assertion, and the values are the reason for revocation. This is only necessary for signed badges.|
 
 
 ### <a id="additional-properties"></a>Additional Properties

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -11,6 +11,27 @@ The Open Badge Infrastructure (OBI) is a set of software tools and specification
 
 ## Table of Contents
 
+* [Introduction](#introduction)
+* [Conventions Used in this Document](#conventions-used-in-this-document)
+* [Intended Audience](#intended-audience)
+* [Terminology](#terminology)
+* [Concepts](#concepts)
+* [Data Model](#data-model)
+	* [Badge Assertion](#badge-assertion)
+	* [Badge Class](#badge-class)
+	* [Issuer Organization](#issuer-organization)
+	* [Summary Tables](#summary-tables)
+	* [Examples](#examples)
+* [Assertion Types](#assertion-types)
+	* [Signed Open Badge Structure](#signed-open-badge-structure)
+* [Additional Properties](#additional-properties)
+* [Issuer Implementations](#issuer-implementations)
+	* [Badge Revocation](#badge-revocation)
+* [Displayer Implementations](#displayer-implementations)
+* [Validation](#validation)
+* [History](#history)
+* [References](#references)
+
 ## Introduction
 
 The Open Badge Infrastructure Assertion specification aims to describe each awarded badge in a way that is open, meaningful and verifiable. An Open Badge Assertion should include all of the information required to understand the award. Each assertion should define these core aspects of a badge award:
@@ -431,7 +452,7 @@ Contact email address for somone at the organization.
 URL for list of revoked badges - _only for signed badges_.<br/>
 _The revocationList endpoint should be a JSON representation of an object where the keys are the uids for revoked badge assertions and the values are the reason for revocation._
 
-#### Summary Tables
+### Summary Tables
 
 <!--see http://tools.ietf.org/html/rfc2360#section-3.2 for status codes etc-->
 
@@ -519,7 +540,7 @@ __Issuer Organization__
 | [`email`](#issuer-organization-email) | O | text |
 | [`revocationList`](#issuer-organization-revocationlist) | O | url |
 
-#### Examples
+### Examples
 
 The three main elements of a badge are: Badge Assertion; Badge Class; Issuer Organization.
 

--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -223,13 +223,11 @@ A Badge Assertion __may__ include:
 The data types and purpose of these properties are as follows.
 
 <a name="assertion-uid"></a>
-* `uid : <text>` __required__
-
+* `uid : <text>` __required__<br/>
 Unique Identifier for the badge assertion. This should be locally unique on a per-origin basis, not globally unique. Badge Issuers should use a unique `uid` value for each Badge Assertion they create (each badge award).
 
 <a name="assertion-recipient"></a>
-* `recipient : `[`IdentityObject`](#identity-object) __required__
-
+* `recipient : `[`IdentityObject`](#identity-object) __required__<br/>
 Definition of Earner identity.
 
 <a name="assertion-badge"></a>

--- a/Badge-Baking/latest.md
+++ b/Badge-Baking/latest.md
@@ -1,10 +1,8 @@
 # Badge Baking
 
-## What Is Badge Baking?
+In Open Badges we use structures called [assertions](../assertion.md). An assertion is a collection of data that can be used to prove whether a not a person who says they got a badge earned it (i.e. that the badge issuer issued the badge to this particular earner).
 
-In OpenBadges we structures called [assertions](../assertion.md), which are pieces of data that can be used to prove whether a not a person who says they got a badge earned it (in the technical sense that it was issued to them).
-
-Badge Baking is the process of taking those assertions and embedding them into the image, so that when a user displays a badge on a page, software that is OpenBadges-aware can automatically extract that assertion data and perform the checks necessary to see if a person legitimately earned the badge.
+Badge Baking is the process of taking an assertion and embedding it into the badge image, so that when a user displays a badge on a page, software that is OpenBadges-aware can automatically extract that assertion data and perform the checks necessary to see if a person legitimately earned the badge (this is _badge verification_). Baking the data into the badge image makes it more portable, allowing the earner to display it wherever they choose.
 
 ## Technical Details
 
@@ -12,7 +10,7 @@ Badge Baking is the process of taking those assertions and embedding them into t
 
 #### Baking
 
-An <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> should be inserted into the PNG with **keyword** `openbadges`. The **text** can either be a signed badge assertion or the raw JSON for the OpenBadges assertion. Compression **MUST NOT** be used. At the moment, *language tag* and *translated keyword* have no semantics related to badge baking.
+An <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> should be inserted into the PNG with **keyword** `openbadges`. The **text** can either be a signed badge assertion or the raw JSON for the Open Badges assertion data. Compression **MUST NOT** be used. At the moment, *language tag* and *translated keyword* have no semantics related to badge baking.
 
 An example of creating a chunk (assuming an iTXt constructor):
 
@@ -27,26 +25,23 @@ var chunk = new iTXt({
 })
 ```
 
-An iTXt chunk with the keyword “openbadges” **MUST NOT** appear in a PNG more than once. When baking a badge that already contains OpenBadges data, the implementor may choose whether to pass the user an error or overwrite the existing chunk.
+An iTXt chunk with the keyword `openbadges` **MUST NOT** appear in a PNG more than once. When baking a badge that already contains Open Badges data, the implementor may choose whether to pass the user an error or overwrite the existing chunk.
 
 #### Extracting
 
-Parse the PNG datastream until the first <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> is found with the keyword `openbadges`. The rest of the stream can be safely discarded. The text portion of the iTXt will either be the JSON representation of an OpenBadges assertion or a signature.
-
-#### Legacy PNGs
-
-The pre-specified behavior of badge baking worked differently. Instead of baking the whole assertion or signature into an `iTXt:openbadges` chunk, the URL pointing to the hosted assertion was baked into a `tEXt:openbadges` chunk. In order to get the full assertion, an additional HTTP request must be made after extracting the URL from the `tEXt` chunk.
+To extract the assertion data from a baked badge, parse the PNG datastream until the first <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> is found with the keyword `openbadges`. The rest of the stream can be safely discarded. The text portion of the iTXt will either be the JSON representation of an Open Badges assertion or a signature.
 
 ### SVGs
 
-#### Baking
-First, Add an `xmlns:openbadges` attribute to the `<svg>` tag with the value "http://openbadges.org". Directly after the `<svg>` tag, add an `<openbadges:assertion>` tag with a `verify` attribute. The value of `verify` should either be a signed OpenBadges assertion **or** the URL from `verify.url` in the badge assertion.
+#### Baking 
 
-If a signature is being baked, no tag body is necessary and the tag should be self closing.
+To create a baked badge using an SVG image, first add an `xmlns:openbadges` attribute to the `<svg>` tag with the value "http://openbadges.org". Directly after the `<svg>` tag, add an `<openbadges:assertion>` tag with a `verify` attribute. The value of `verify` should either be a signed Open Badges assertion **or** the URL from the `verify.url` field in the badge assertion.
 
-If an assertion is being baked, the JSON representation of the assertion should go into the body of the tag, wrapped in `<![CDATA[...]]>`.
+__If a signature is being baked__: no tag body is necessary and the tag should be self-closing.
 
-An example of a well baked SVG with a hosted assertion:
+__If a JSON assertion is being baked__: the JSON should go into the body of the tag, wrapped in `<![CDATA[...]]>`.
+
+An example of a well-baked SVG with a hosted assertion:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -76,10 +71,10 @@ An example of a well baked SVG with a hosted assertion:
 </svg>
 ```
 
-There **MUST** be only one `<openbadges:assertion>` tag in an SVG. When baking a badge that already contains OpenBadges data, the implementor may choose whether to pass the user an error or overwrite the existing tag.
+There **MUST** be only one `<openbadges:assertion>` tag in an SVG. When baking a badge that already contains Open Badges data, the implementor may choose whether to pass the user an error or overwrite the existing tag.
 
 #### Extracting
 
-Parse the SVG until you reach the first `<openbadges:assertion>` tag. The rest of the SVG data can safely be discarded.
+To extract the assertion data from a baked SVG bage, parse the SVG until you reach the first `<openbadges:assertion>` tag. The rest of the SVG data can safely be discarded.
 
-If the tag has no body, the `verify` attribute will contain the signature of the badge. If there is a body, it will be the JSON representation of a badge assertion.
+If the tag has no body, the `verify` attribute will contain the signature of the badge - if there is a body, it will contain the JSON representation of the badge assertion.

--- a/Badge-Baking/latest.md
+++ b/Badge-Baking/latest.md
@@ -89,4 +89,5 @@ To extract the assertion data from a baked SVG bage, implementors __should__:
  * The rest of the SVG data can safely be discarded.
 
 ___If the element has no body___: the `verify` attribute will contain the signature of the badge.
+
 ___If the element has a body___: it will contain the JSON representation of the badge assertion.

--- a/Badge-Baking/latest.md
+++ b/Badge-Baking/latest.md
@@ -23,7 +23,7 @@ Baked badges are either [PNGs](#png-badges) or [SVGs](#svg-badges). This documen
 
 ## Conventions Used in this Document
 
-> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Intended Audience
 
@@ -211,4 +211,4 @@ To extract the assertion data from a baked SVG bage, implementors __should__:
 The data within the `<openbadges:assertion>` element will either be in the body or in an attribute, depending on whether the badge is signed or hosted.
 
 * ___If the element has no body___: the `verify` attribute will contain the signature of the badge.
-* ___If the element has a body___: it will contain the JSON representation of the badge assertion.
+* ___If the element has a body___: it should contain the JSON representation of the badge assertion.

--- a/Badge-Baking/latest.md
+++ b/Badge-Baking/latest.md
@@ -1,16 +1,133 @@
-# Badge Baking
+# Open Badges Baking Specification
+
+## Introduction
 
 The metadata describing an Open Badge awarded to an earner is an [assertion](../Assertion/latest.md). A baked badge is a badge image with the assertion data embedded into it. The assertion for a badge can be used to verify its authenticity - to prove whether or not it was awarded by the issuer to the earner claiming it.
 
 Badge Baking is the process of taking an assertion and embedding it into the badge image. When a user displays a baked badge on a page, software can extract that assertion data - then perform verification checks on it. Baking the data into the badge image makes it more portable, allowing the earner to display it wherever they choose.
 
-Baked badges are either [PNGs](#pngs) or [SVGs](#svgs). This document outlines the technical implementation for baked badges of both types.
+Baked badges are either [PNGs](#png-badges) or [SVGs](#svg-badges). This document outlines the technical implementation for baked badges of both types.
 
-## Technical Details
+## Table of Contents
 
-### PNGs
+* [Conventions Used in this Document](#conventions-used-in-this-document)
+* [Intended Audience](#intended-audience)
+* [Concepts](#concepts)
+* [Terminology](#terminology)
+* [PNG Badges](#png-badges)
+ * [Baking](#baking-pngs)
+ * [Extracting](#extracting-pngs)
+* [SVG Badges](#svg-badges)
+ * [Baking](#baking-svgs)
+ * [Extracting](#extracting-svgs)
 
-#### Baking
+## Conventions Used in this Document
+
+> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Intended Audience
+
+This document is intended for the following audiences:
+
+* implementers of badge issuing applications
+* implementers of badge displaying applications
+
+The primary audience is expected to be software developers.
+
+The Open Badges Baking specification relies on structures using JSON syntax - see [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt) and [JSON.org](http://www.json.org/).
+
+## Concepts
+
+Implementing badge baking within the OBI involves understanding a range of concepts which refer to well-known real-world objects and activities, but which have specific meanings within the Open Badges ecosystem.
+
+An Open Badge is a digital representation of a skill or achievement, communicated via an image plus JSON data structures. An awarded badge is defined using a ___Badge Assertion___, which can be represented as a JSON file or a JSON Web Signature (JWS).
+
+People who are awarded Open Badges are referred to as ___Earners___. The people and organizations who award Open Badges are referred to as ___Issuers___. Issuing is the technical act of awarding a badge, the implementation of which is creating a ___Badge Assertion___.
+
+___Displayers___ of Open Badges are implementers of systems in which awarded badges are presented in digital contexts. ___Displayers___ therefore deal with the data in ___Badge Assertions___, which is created by ___Issuers___. 
+
+___Issuers___ can create ___Baked Badges___ by embedding ___Badge Assertions___ into badge images. This means that the data for the awarded badge is all contained in/ linked from a single image file.
+
+For Open Badges to comprise valuable representations of achievement, they must facilitate verification processes. ___Issuers___ are responsible for including the information necessary for this verification, while ___Displayers___ are responsible for using it to check that a badge was awarded by an ___Issuer___, to an ___Earner___. In order to verify a ___Baked Badge___, ___Displayers___ must first extract the assertion data from the badge image.
+
+## Terminology
+
+The Open Badges Baking specification uses the following terms as defined:
+
+<a name="term-badge-assertion"><a>
+__Badge Assertion__
+
+A JSON-structured representation of a badge awarded to an Earner. An Assertion describes the badge [Earner](#term-earner), what the badge represents and the [Issuer](#term-issuer). The data items within an Assertion include: a unique ID; the Earner (recipient) identity; details of the Badge Class (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge).
+
+<a name="term-award"></a>
+__Award__
+
+In the Open Badges ecosystem, the terms "issue" and "award" are synonymous. To award a badge is to [issue](#term-issue) it - this involves the badge [Issuer](#term-issuer) creating a [Badge Assertion](#term-badge-assertion) to describe the award.
+
+<a name="term-badge"></a>
+__Badge__
+
+In the context of the OBI, a badge is loosely described as a digital representation of a skill, learning achievement or experience. A badge is represented in digital contexts as an image and some metadata. For the badge to exist within the OBI, this metadata __must__ conform to the [Assertion specification](../Assertion/latest.md).
+
+<a name="term-bake"></a>
+__Bake, Baking, Baked Badge__
+
+A baked badge is a badge image file with the data for an [Assertion](#term-badge-assertion) embedded into it. The image __must__ be either a PNG or SVG file. Baked badges are more portable, allowing [Earners](#term-earner) to communicate and display them wherever they choose. Software can extract the Assertion data from a baked badge to access the metadata describing the award.
+
+<a name="term-displayer"></a>
+__Displayer__
+
+A badge Displayer presents information about public badge awards in a digital context. Badge [Earners](#term-earner) can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers require an understanding of the Assertion structure and Baking process in order to extract and display the relevant data within their applications. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
+
+<a name="term-earner"></a>
+__Earner__
+
+An Earner is someone who has been awarded one or more Open Badges. When an [Issuer](#term-issuer) awards a badge, they build information about the Earner identity into a new [Badge Assertion](#term-badge-assertion), which links to information about what the badge represents.
+
+<a name="term-hosted-badge"></a>
+__Hosted Badge__
+
+A ___hosted___ badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a ___hosted___ badge are: the [Badge Assertion](#term-badge-assertion); the Badge Class; the Issuer Organization. The Badge Assertion includes a [verification](#term-verify) field in which either a ___hosted___ or [___signed___](#term-signed-badge) type is specified.
+
+<a name="term-issue"></a>
+__Issue__
+
+Issuing is the act of awarding a badge to an [Earner](#term-earner). Badge [Issuers](#term-issuer) create badges and decide who to award them to. In order to issue a badge within the OBI, an Issuer __must__ create a [Badge Assertion](#term-badge-assertion), which __may__ be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge). The Issuer may optionally [bake](#term-bake) the Assertion into the badge image.
+
+<a name="term-issuer"></a>
+__Issuer__
+
+An Issuer is a person or organization (or department within an organization) who awards Open Badges to [Earners](#term-earner). Typically the Issuer is responsible for designing and creating the badge as well as awarding it. 
+
+<a name="term-metadata"></a>
+__Metadata__
+
+In the OBI, metadata is information about badges, badge awards and badge Issuers. OBI metadata is defined in JSON as part of the [Assertion specification](../Assertion/latest.md). The Assertion metadata structures are designed for interoperability.
+
+<a name="term-obi"></a>
+__Open Badge Infrastructure (OBI)__
+
+The OBI is a set of software tools and specifications to support Open Badge systems. These tools provide a framework for issuing, displaying and earning Open Badges within an open ecosystem.
+
+<a name="term-signed-badge"></a>
+__Signed Badge__
+
+A ___signed___ badge has its Assertion data included in a JSON Web Signature (JWS). Typically a ___signed___ badge still uses hosted JSON files for the Badge Class and Issuer Organization, but the [Badge Assertion](#term-badge-assertion) JSON is itself packaged as a signature. The Badge Assertion includes a [verification](#term-verify) field in which either a [___hosted___](#term-hosted) or ___signed___ type is specified.
+
+<a name="term-validate"></a>
+__Validate, Validation, Validator__
+
+Validation is the act of checking a [Badge Assertion](#term-badge-assertion) for structural validity. This includes verifying well-formedness and correctness of data types, as well as ensuring that any linked resources are available.
+
+<a name="term-verify"></a>
+__Verify, Verification__
+
+Verification is the act of checking that a badge was awarded by the [Issuer](#term-issuer) to the [Earner](#term-earner). Badge [Displayers](#term-displayer) __should__ carry out verification on badges before displaying them. Badge Issuers __should__ include the information necessary for this verification to be implemented in [Badge Assertions](#term-badge-assertion). Verification is tailored to whether a Badge Assertion is [___signed___](#term-signed-badge) or [___hosted___](#term-hosted-badge).
+
+## PNG Badges
+
+<a name="baking-pngs"></a>
+### Baking
 
 An <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> __must__ be inserted into the PNG with the ___keyword___ `openbadges`. The text __must__ either be a ___signed badge assertion (JWS)___ or the ___raw JSON for the Open Badges assertion data___. Compression __must not__ be used. 
 
@@ -32,13 +149,15 @@ var chunk = new iTXt({
 * An `iTXt` chunk with the keyword `openbadges` __must not appear in a PNG more than once__. 
 * When baking a badge that already contains Open Badges data, the implementor may choose whether to _pass the user an error or overwrite the existing chunk_.
 
-#### Extracting
+<a name="extracting-pngs"></a>
+### Extracting
 
 To extract the assertion data from a baked badge, implementors __should__ parse the PNG datastream until the ___first___ <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> is found with the keyword `openbadges`. The rest of the stream can be safely discarded. The text portion of the `iTXt` will either be the JSON representation of an Open Badges assertion or a JSON Web Signature.
 
-### SVGs
+## SVG Badges
 
-#### Baking 
+<a name="baking-svgs"></a>
+### Baking 
 
 To create a baked badge using an SVG image, implementors should:
 
@@ -82,12 +201,14 @@ An example of a well-baked SVG with a hosted assertion follows:
 
 There __must__ be ___only one___ `<openbadges:assertion>` element in a baked SVG. When baking a badge that already contains Open Badges data, the implementor __may__ choose whether to _pass the user an error or overwrite the existing element_.
 
-#### Extracting
+<a name="extracting-svgs"></a>
+### Extracting
 
 To extract the assertion data from a baked SVG bage, implementors __should__:
 * Parse the SVG until the ___first___ `<openbadges:assertion>` tag is reached. 
  * The rest of the SVG data can safely be discarded.
 
-___If the element has no body___: the `verify` attribute will contain the signature of the badge.
+The data within the `<openbadges:assertion>` element will either be in the body or in an attribute, depending on whether the badge is signed or hosted.
 
-___If the element has a body___: it will contain the JSON representation of the badge assertion.
+* ___If the element has no body___: the `verify` attribute will contain the signature of the badge.
+* ___If the element has a body___: it will contain the JSON representation of the badge assertion.

--- a/Badge-Baking/latest.md
+++ b/Badge-Baking/latest.md
@@ -57,7 +57,7 @@ The Open Badges Baking specification uses the following terms as defined:
 <a name="term-badge-assertion"><a>
 __Badge Assertion__
 
-A JSON-structured representation of a badge awarded to an Earner. An Assertion describes the badge [Earner](#term-earner), what the badge represents and the [Issuer](#term-issuer). The data items within an Assertion include: a unique ID; the Earner (recipient) identity; details of the Badge Class (what the award represents); verification data; the date the badge was issued. Assertions can additionally include a range of optional data items and can be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge).
+A JSON-structured representation of a badge awarded to an Earner. An Assertion describes the badge [Earner](#term-earner), what the badge represents and the [Issuer](#term-issuer). Assertions can be [___hosted___](#term-hosted-badge) or [___signed___](#term-signed-badge).
 
 <a name="term-award"></a>
 __Award__
@@ -77,17 +77,17 @@ A baked badge is a badge image file with the data for an [Assertion](#term-badge
 <a name="term-displayer"></a>
 __Displayer__
 
-A badge Displayer presents information about public badge awards in a digital context. Badge [Earners](#term-earner) can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers require an understanding of the Assertion structure and Baking process in order to extract and display the relevant data within their applications. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
+A badge Displayer presents information about public badge awards in a digital context. Badge [Earners](#term-earner) can add their awarded badges to public collections, which Displayer implementations can query, typically presenting the information about the badge award alongside its image. Badge Displayers require an understanding of the [Assertion](#term-badge-assertion) structure and Baking process in order to extract and display the relevant data within their applications. Badge Displayers __should__ [verify](#term-verify) Assertions prior to displaying them to ensure that a particular badge was in fact awarded to the Earner claiming it.
 
 <a name="term-earner"></a>
 __Earner__
 
-An Earner is someone who has been awarded one or more Open Badges. When an [Issuer](#term-issuer) awards a badge, they build information about the Earner identity into a new [Badge Assertion](#term-badge-assertion), which links to information about what the badge represents.
+An Earner is someone who has been awarded one or more Open Badges. When an [Issuer](#term-issuer) awards a badge, they build information about the Earner identity into a new [Badge Assertion](#term-badge-assertion), which links to information about what the badge represents. If the Issuer provides a baked badge image for an awarded badge, the Earner can potentially display it in multiple contexts.
 
 <a name="term-hosted-badge"></a>
 __Hosted Badge__
 
-A ___hosted___ badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a ___hosted___ badge are: the [Badge Assertion](#term-badge-assertion); the Badge Class; the Issuer Organization. The Badge Assertion includes a [verification](#term-verify) field in which either a ___hosted___ or [___signed___](#term-signed-badge) type is specified.
+A ___hosted___ badge is one whose Assertion data is represented using the badge image and three JSON files hosted at stable locations. The component parts of a ___hosted___ badge are: the [Badge Assertion](#term-badge-assertion); the Badge Class (what the badge represents); the Issuer Organization (who issued it). The Badge Assertion includes a [verification](#term-verify) field in which either a ___hosted___ or [___signed___](#term-signed-badge) type is specified.
 
 <a name="term-issue"></a>
 __Issue__
@@ -112,7 +112,7 @@ The OBI is a set of software tools and specifications to support Open Badge syst
 <a name="term-signed-badge"></a>
 __Signed Badge__
 
-A ___signed___ badge has its Assertion data included in a JSON Web Signature (JWS). Typically a ___signed___ badge still uses hosted JSON files for the Badge Class and Issuer Organization, but the [Badge Assertion](#term-badge-assertion) JSON is itself packaged as a signature. The Badge Assertion includes a [verification](#term-verify) field in which either a [___hosted___](#term-hosted) or ___signed___ type is specified.
+A ___signed___ badge has its Assertion data included in a JSON Web Signature (JWS). Typically a ___signed___ badge still uses hosted JSON files for the Badge Class (what the badge represents) and Issuer Organization (who issued it), but the [Badge Assertion](#term-badge-assertion) JSON is itself packaged as a signature. The Badge Assertion includes a [verification](#term-verify) field in which either a [___hosted___](#term-hosted) or ___signed___ type is specified.
 
 <a name="term-validate"></a>
 __Validate, Validation, Validator__
@@ -129,7 +129,7 @@ Verification is the act of checking that a badge was awarded by the [Issuer](#te
 <a name="baking-pngs"></a>
 ### Baking
 
-An <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> __must__ be inserted into the PNG with the ___keyword___ `openbadges`. The text __must__ either be a ___signed badge assertion (JWS)___ or the ___raw JSON for the Open Badges assertion data___. Compression __must not__ be used. 
+An <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> __must__ be inserted into the PNG with the ___keyword___ `openbadges`. The text __must__ either be a ___signed badge assertion (JWS)___ OR the ___raw JSON for the Open Badges assertion data___. Compression __must not__ be used. 
 
 At the moment, _language tag_ and _translated keyword_ have no semantics related to badge baking.
 
@@ -147,27 +147,28 @@ var chunk = new iTXt({
 ```
 
 * An `iTXt` chunk with the keyword `openbadges` __must not appear in a PNG more than once__. 
-* When baking a badge that already contains Open Badges data, the implementor may choose whether to _pass the user an error or overwrite the existing chunk_.
+* When baking a badge that already contains Open Badges data, the implementer __may__ choose whether to _pass the user an error OR overwrite the existing chunk_.
 
 <a name="extracting-pngs"></a>
 ### Extracting
 
-To extract the assertion data from a baked badge, implementors __should__ parse the PNG datastream until the ___first___ <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> is found with the keyword `openbadges`. The rest of the stream can be safely discarded. The text portion of the `iTXt` will either be the JSON representation of an Open Badges assertion or a JSON Web Signature.
+To extract the assertion data from a baked badge, implementers __should__ parse the PNG datastream until the ___first___ <a href="http://www.w3.org/TR/PNG/#11iTXt">`iTXt` chunk</a> is found with the keyword `openbadges`. The rest of the stream __may__ be safely discarded. The text portion of the `iTXt` should either be the JSON representation of an Open Badges assertion OR a JSON Web Signature.
 
 ## SVG Badges
 
 <a name="baking-svgs"></a>
 ### Baking 
 
-To create a baked badge using an SVG image, implementors should:
+To create a baked badge using an SVG image, implementers __must__:
 
 * Add an `xmlns:openbadges` attribute to the opening `<svg>` tag with the value `http://openbadges.org`. 
 * Directly after the opening `<svg>` tag (as the `svg` element's first child), add an `<openbadges:assertion>` element with a `verify` attribute. 
- * The value of `verify` __must__ either be a ___signed Open Badges assertion (JWS)___ __or__ the ___URL of the hosted badge assertion___ (from the `verify.url` field in the badge assertion).
+ * The value of `verify` __must__ either be a ___signed Open Badges assertion (JWS)___ OR the ___URL of the hosted badge assertion___ (from the `verify.url` field in the badge assertion).
 
-__If a JSON Web Signature is being baked__: no tag body is necessary and the tag should be self-closing.
+The structure of the `<openbadges:assertion>` element __must__ be tailored to whether the badge is signed or hosted:
 
-__If a JSON assertion is being baked__: the JSON should go into the body of the tag, wrapped in `<![CDATA[...]]>` tags.
+* ___If a JSON Web Signature is being baked___: no tag body is necessary and the tag should be self-closing.
+* ___If a JSON assertion is being baked___: the JSON should go into the body of the tag, wrapped in `<![CDATA[...]]>` tags.
 
 An example of a well-baked SVG with a hosted assertion follows:
 
@@ -199,16 +200,16 @@ An example of a well-baked SVG with a hosted assertion follows:
 </svg>
 ```
 
-There __must__ be ___only one___ `<openbadges:assertion>` element in a baked SVG. When baking a badge that already contains Open Badges data, the implementor __may__ choose whether to _pass the user an error or overwrite the existing element_.
+There __must__ be ___only one___ `<openbadges:assertion>` element in a baked SVG. When baking a badge that already contains Open Badges data, the implementer __may__ choose whether to _pass the user an error OR overwrite the existing element_.
 
 <a name="extracting-svgs"></a>
 ### Extracting
 
-To extract the assertion data from a baked SVG bage, implementors __should__:
+To extract the assertion data from a baked SVG bage, implementers __should__:
 * Parse the SVG until the ___first___ `<openbadges:assertion>` tag is reached. 
- * The rest of the SVG data can safely be discarded.
+ * The rest of the SVG data __may__ be safely discarded.
 
-The data within the `<openbadges:assertion>` element will either be in the body or in an attribute, depending on whether the badge is signed or hosted.
+The data within the `<openbadges:assertion>` element should either be in the body or in an attribute, depending on whether the badge is signed or hosted.
 
-* ___If the element has no body___: the `verify` attribute will contain the signature of the badge.
+* ___If the element has no body___: the `verify` attribute will contain the JSON Web Signature for the badge assertion.
 * ___If the element has a body___: it should contain the JSON representation of the badge assertion.

--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@ A repository for the main Open Badges specifications.
 * [Assertion](/Assertion/latest.md): Main specification for the badge data. If you want to understand how badges are made and verified, this is the place to look.
 
 * [Baking](/Badge-Baking/latest.md): Badge “baking” is the process of embedding a badge assertion into an image (a PNG or an SVG) so that where ever that image goes, the assertion data goes with it and the badge can be independently verified.
-
-* [Backpack](/backpack.md) [**TODO**]: A badge “backpack” is a web site/application that can take in & export badges. The Open Badges JavaScript API expects endpoints to be in specific or discoverable locations, and this document details that.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 A repository for the main Open Badges specifications.
 
-* [Assertion](/Assertion/latest.md): Main specification for the badge data. If you want to understand how badges are made and verified, this is the place to look.
+* [Assertion](/Assertion/latest.md): Main specification for badge data. Outlines the structure of the component parts in an awarded badge, including the generic badge definition and issuer organization.
 
-* [Baking](/Badge-Baking/latest.md): Badge “baking” is the process of embedding a badge assertion into an image (a PNG or an SVG) so that where ever that image goes, the assertion data goes with it and the badge can be independently verified.
+* [Baking](/Badge-Baking/latest.md): Badge "baking" is the process of embedding a badge assertion into an image (a PNG or an SVG) so that where ever that image goes, the assertion data goes with it and the badge can be independently verified.


### PR DESCRIPTION
Opening this up for input although there are still a few blanks. As discussed in #7 I've had a go at redrafting the assertion spec with standards language/ guidance in mind:

* https://www.ietf.org/rfc/rfc2119.txt
* http://tools.ietf.org/html/rfc2223
* http://tools.ietf.org/html/rfc2360

Also used these W3C examples:

* http://www.w3.org/TR/json-ld
* http://www.w3.org/TR/SVG/struct.html

__Assertion Spec Notes__:
* blanks include "Status of this Document", "History" and "References"
 * I've left notes in code comments in some parts of the document linking to relevant IETF guidance
 * haven't gone into much detail in terms of context - the History section could maybe go into this, i.e. outlining the decision history, explaining why aspects of the spec are the way they are etc
* have removed the "Setting Content-Type" examples section, thought that might belong in a separate guide
* am assuming the spec may need significant additions pending discussions regarding extensions/ inline objects etc

__General Notes:__
* have removed link to Backpack "todo" page from repo readme
* have redrafted the baking doc but not with standards language etc in mind so it's still in the original format

Closes #6 
Closes #7 