### PR TITLE
Add CNAME record to allow domain mapping for GH-pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+standard.openbadges.org


### PR DESCRIPTION
Once a CNAME is set up on the DNS record, this pull request can be merged to update the GH Pages settings to properly map the http://standard.openbadges.org domain to this site.