### PR TITLE
Feature/vocab claim bugfix

### DIFF
--- a/credentials/context.json
+++ b/credentials/context.json
@@ -16,7 +16,7 @@
     "DefinedAchievement": "credentials:DefinedAchievement",
     "DefinedAchievementAssertion": "credentials:DefinedAchievementAssertion",
 
-    "claim": { "@id": "credentials:claim", "@type": "ClaimSet" },
+    "claim": { "@id": "credentials:claim", "@type": "@id" },
     "name": { "@id": "schema:name", "@type": "xsd:string" },
     "description": { "@id": "schema:description", "@type": "xsd:string" },
     "image": { "@id": "schema:image", "@type": "@id" },

--- a/credentials/index.html
+++ b/credentials/index.html
@@ -240,7 +240,7 @@
           <dd>
             <a href="#id">id</a>, 
             <a href="#badge">badge</a>,
-            <a href="#claim">claims</a>
+            many different claim properties
           </dd>
         </dl>
         <p>
@@ -403,11 +403,11 @@
           </dd>
           <dt>Typically used by</dt>
           <dd>
-            <a href="#Claim">Claim Set</a>
+            <a href="#Credential">Credential</a>
           </dd>
           <dt>Associated value must be an</dt>
           <dd>
-            ... something that makes sense for the term?
+            <a href="#Claim">Claim Set</a>
           </dd>
         </dl>
 

--- a/credentials/index.html
+++ b/credentials/index.html
@@ -205,21 +205,19 @@
         <pre class="example highlight language-jsonld">
 {
   "@context": "https://w3id.org/credentials/v1",
-  "credential": [{
-    "id": "http://biguniversity.gov/credentials/53091",
-    "type": "BasicInfo",
-    "claim": {
-      "id": "https://example.com/identities/bob",
-      "name": "Bob Bobman",
-      "birthdate": "1985-12-14"
-    },
-    "expires": "2018-01-01",
-    "signature": {
-       "type": "GraphSignature2012",
-       "creator": "https://biguniversity.edu/keys/1",
-       "signature": "3780eyfh3q0fhhfiq3q9f8ahsidfhf29rhaish"
-    }
-  }]
+  "id": "http://biguniversity.gov/credentials/53091",
+  "type": "BasicInfo",
+  "claim": {
+    "id": "https://example.com/identities/bob",
+    "name": "Bob Bobman",
+    "birthdate": "1985-12-14"
+  },
+  "expires": "2018-01-01",
+  "signature": {
+     "type": "GraphSignature2012",
+     "creator": "https://biguniversity.edu/keys/1",
+     "signature": "3780eyfh3q0fhhfiq3q9f8ahsidfhf29rhaish"
+  }
 }
         </pre>
       </section>


### PR DESCRIPTION
Fixes one issue I noticed myself, one issue that @erickorb, @dlongley and @msporny noticed, and one issue that @elf-pavlik noted.

* `claim` is a property of a `Credential`. It's associated value must be a `ClaimSet`.
* The `@type` value in the context for `claim` must be `@id`, not `ClaimSet` -- @type is for datatypes of literal values, not class types of JSON object literals.
* Took example 2 (Credential) out of an ambiguous wrapper so it appears on its own. As embedded in an Identity document, it wouldn't have the context link in this spot, but when freestanding it would.

Thanks for feedback, all.