### PR TITLE
Update 1.1 examples to https

### DIFF
--- a/history/1.1.md
+++ b/history/1.1.md
@@ -21,9 +21,9 @@ To change hosted 1.0 resources to 1.1, add the three new fields to each badge ob
 ### Assertion
 {% highlight json %}
 {
-"@context": "http://w3id.org/openbadges/v1",
+"@context": "https://w3id.org/openbadges/v1",
 "type": "Assertion",
-"id": "http://mydomain.org/assertion/50",
+"id": "https://mydomain.org/assertion/50",
 ...
 }
 {% endhighlight %}
@@ -31,9 +31,9 @@ To change hosted 1.0 resources to 1.1, add the three new fields to each badge ob
 ### BadgeClass
 {% highlight json %}
 {
-  "@context": "http://w3id.org/openbadges/v1",
+  "@context": "https://w3id.org/openbadges/v1",
   "type": "BadgeClass",
-  "id": "http://mydomain.org/badges/1",
+  "id": "https://mydomain.org/badges/1",
   ...
 }
 {% endhighlight %}
@@ -41,9 +41,9 @@ To change hosted 1.0 resources to 1.1, add the three new fields to each badge ob
 ### Issuer
 {% highlight json %}
 {
-  "@context": "http://w3id.org/openbadges/v1",
+  "@context": "https://w3id.org/openbadges/v1",
   "type": "Issuer",
-  "id": "http://mydomain.org/issuer",
+  "id": "https://mydomain.org/issuer",
   ...
 }
 {% endhighlight %}


### PR DESCRIPTION
Thanks, @erickorb and @msporny for reporting that the 1.1 history/changelog page incorrectly advised implementers to use insecure `http` for the context URL instead of `https`. Indeed HTTPS should be used.