### PR TITLE
Reestablish xsd:dateTime format for issuedOn and expires

### DIFF
--- a/v0/context.json
+++ b/v0/context.json
@@ -28,9 +28,9 @@
     "hashed": { "@id": "obi:hashed", "@type": "xsd:boolean" },
     "salt": { "@id": "obi:salt" },
     "identity": { "@id": "obi:identityHash" },
-    "issuedOn": { "@id": "obi:issueDate" },
+    "issuedOn": { "@id": "obi:issueDate", "@type": "xsd:dateTime" },
     "issued_on": "issuedOn",
-    "expires": { "@id": "sec:expiration" },
+    "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
     "evidence": { "@id": "obi:evidence", "@type": "@id" },
     "verify": { "@id": "obi:verify", "@type": "@id" },
 

--- a/v1/context.json
+++ b/v1/context.json
@@ -32,8 +32,8 @@
     "hashed": { "@id": "obi:hashed", "@type": "xsd:boolean" },
     "salt": { "@id": "obi:salt" },
     "identity": { "@id": "obi:identityHash" },
-    "issuedOn": { "@id": "obi:issueDate" },
-    "expires": { "@id": "sec:expiration" },
+    "issuedOn": { "@id": "obi:issueDate", "@type": "xsd:dateTime" },
+    "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
     "evidence": { "@id": "obi:evidence", "@type": "@id" },
     "verify": { "@id": "obi:verify", "@type": "@id" },
 


### PR DESCRIPTION
Badge products will need to translate dateTime stamps into xsd:dateTime / ISO 8601 before doing Linked Data processing, or they may encounter slight compaction errors yielding incorrect compact IRIs.

See http://docstore.mik.ua/orelly/xml/schema/ch04_05.htm for documentation.