### PR TITLE
Community extension: Original Creator

### DIFF
--- a/extensions/index.md
+++ b/extensions/index.md
@@ -175,5 +175,38 @@ Assertion, BadgeClass, Issuer
 }
 {% endhighlight %}
 
+### <a name="OriginalCreator"></a> Original Creator
+This extension provides a way to track the origin of a badge when one organisation creates it for another.
+
+For example, presume we have organisations X, Y and Z. A badge is created by X and they grant Y and Z the right to issue it.
+IssuerClass of X is stored as the OriginalCreator in the BadgeClass and either Y or Z becomes the issuer.
+
+
+{::options parse_block_html="true" /}
+<div class="table-wrapper">
+
+Property     | Type        | Value Description
+-------------|-------------|---------
+**@context** | context IRI | [https://openbadgespec.org/extensions/originalCreatorExtension/context.json](./originalCreatorExtension/context.json)
+**type**    | type IRI array |`['Extension', 'extensions:OriginalCreator']`
+**url** | string,uri | Valid url pointing to the IssuerClass document of the original creator of this badge
+
+</div>
+
+**Extendable Badge Objects:**
+BadgeClass
+
+**Example implementation:**
+{% highlight json %}
+{ 
+  "extensions:OriginalCreator": {
+    "@context":"https://openbadgespec.org/extensions/originalCreatorExtension/context.json",
+    "type": ["Extension", "extensions:OriginalCreator"],
+    "url": "https://example.org/creator-organisation.json"
+  }
+}
+{% endhighlight %}
+
+
 # xAPI Integration
 An exploratory prototype draft xAPI vocabulary has been defined so that Open Badges will soon be referencable from Experience API activity streams. See [xAPI Open Badges documentation]({{site.baseurl}}/xapi/) for details.

--- a/extensions/originalCreatorExtension/context.json
+++ b/extensions/originalCreatorExtension/context.json
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "obi": "https://w3id.org/openbadges#",
+    "extensions": "https://w3id.org/openbadges/extensions#",
+    "url": "extensions:#originalCreator"
+  },
+  "obi:validation": [
+    {
+      "obi:validatesType": "extensions#originalCreatorExtension",
+      "obi:validationSchema": "https://openbadgespec.org/extensions/originalCreatorExtension/schema.json"
+    }
+  ]
+}

--- a/extensions/originalCreatorExtension/schema.json
+++ b/extensions/originalCreatorExtension/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Original Creator",
+  "description": "When a badge is shared with another issuer, this extension allows you to show the original creator of the badge.",
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "required": ["url"]
+}


### PR DESCRIPTION
This extension provides a way to track the origin of a badge when one
organisation creates it for others.

For example, presume we have organisations X, Y and Z. A badge is
created by X and they grant Y and Z the right to issue it.  IssuerClass
of X is stored as the OriginalCreator in the BadgeClass and either Y or
Z becomes the issuer.