### PR TITLE
Changed uniqueness property to uniqueItems

### DIFF
--- a/v1/schema/badgeclass.json
+++ b/v1/schema/badgeclass.json
@@ -82,7 +82,7 @@
       "items": {
         "type": "string"
       },
-      "uniqueness": true
+      "uniqueItems": true
     }
   },
   "properties": {


### PR DESCRIPTION
In the current version of the BadgeClass schema, the TagsArray definition has a property called "uniqueness" to denote that the values in that array should be unique. However, this is not a supported property in the [JSON Schema specification](http://json-schema.org/draft-04/schema#).

```json
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "properties": {
       "uniqueItems": {
            "type": "boolean",
            "default": false
        }
    }
}
```