### PR TITLE
Fallback to monospace font for code

### DIFF
--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -69,7 +69,7 @@ blockquote {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
   color:#333;
   font-size:12px;
 }


### PR DESCRIPTION
On my system (Ubuntu 16.10, Chrome), code displays with a non-monospace font, which makes it really hard to read. This is because all fonts that are used in the stylesheet for code are neither installed on my system nor imported by the document. As a quick fix, this PR adds a fallback to `monospace`, which should be available everywhere.