### PR TITLE
remove trailing comma

### DIFF
--- a/v2/context.json
+++ b/v2/context.json
@@ -86,6 +86,6 @@
     "validationSchema": "obi:validationSchema",
     "verification": { "@id": "obi:verify", "@type": "@id" },
     "verificationProperty": { "@id": "obi:verificationProperty" },
-    "verify": "verification",
+    "verify": "verification"
   }
 }


### PR DESCRIPTION
When I try to reference the v2 context, I get the following error (through JSON-LD playground). I think it's just the trailing comma

```
Dereferencing a URL did not result in a valid JSON-LD object. Possible causes are an inaccessible URL perhaps due to a same-origin policy (ensure the server uses CORS if you are using client-side JavaScript), too many redirects, a non-JSON response, or more than one HTTP Link Header was provided for a remote context.
```