### PR TITLE
Fix table markdown rendering in Endorsement section

### DIFF
--- a/index.md
+++ b/index.md
@@ -458,6 +458,7 @@ Open Badges are trustworthy records of achievement. The vocabulary defined above
 Endorsement leans on the Verifiable Claims work prototyped by members of the [Verifiable Claims Task Force](https://w3c.github.io/vctf/) at the [W3C](https://www.w3.org/) and the theoretical backing developed by the 2014 Endorsement Working Group. See [Endorsement Framework Paper](https://docs.google.com/document/d/1VVf19d72KmGMh1ywrLe7HCKEOqGSI0WjvwfGN_8Q2M4/edit#heading=h.xyxfmzqz2vqb).
 
 The `Endorsement` Class is very similar to `Assertion`, except that there is no defined `badge` property. Instead, a `claim` property allows endorsers to make specific claims about other `Profiles`, `BadgeClasses`, or `Assertions`.
+
 <div class="table-wrapper">
 
 Property | Expected Type | Description/expected value
@@ -474,6 +475,7 @@ Property | Expected Type | Description/expected value
 Within the `claim` property, the endorsed entity may be of any type (though only Open Badges Vocabulary classes are expected to be understood by Open Badges-specific tools. While `Endorsement` is a very flexible data structure, its usefulness will be limited not by the creativity of endorsers, but by the ability for other tools to discover and understand those endorsements.
 
 There is one special property for use in endorsement, the `endorsementComment`, which allows endorsers to make a simple claim in writing about the entity.
+
 <div class="table-wrapper">
 
 Property | Expected Type | Description/expected value


### PR DESCRIPTION
This fixes #116 by inserting CRs before two div.tablewrapper open tags.
