### PR TITLE
Fix usage of incorrect property in 'A Simple Example'. Resolves #120.

### DIFF
--- a/index.md
+++ b/index.md
@@ -66,7 +66,7 @@ Open Badges contain detailed metadata about achievements. Who earned a badge, wh
     "type": "email",
     "identity": "alice@example.org"
   },
-  "created": "2016-12-31T23:59:59+00:00",
+  "issuedOn": "2016-12-31T23:59:59+00:00",
   "verification": {
     "type": "hosted"
   },
@@ -90,7 +90,6 @@ Open Badges contain detailed metadata about achievements. Who earned a badge, wh
       }
     }
   }
-
 }
 {% endhighlight %}
 


### PR DESCRIPTION
Resolves #120. Usage of an incorrect property, though valid JSON-LD in the v2 context, made the Simple Example at the top of the spec an invalid Assertion. `issuedOn` is required. `created` is a similar term from a different vocabulary used for signature creation dates.