### PR TITLE
Remove "In development bullet" for multilingual badges (#105)

### DIFF
--- a/index.md
+++ b/index.md
@@ -164,7 +164,6 @@ Open Badges are used by thousands of issuers around the world, and users of thos
 
 * Declare which language a Badge Object is expressed in using language tags compliant with [BCP47](https://tools.ietf.org/html/bcp47).
 * List multiple versions of Badge Objects to make available multiple equivalent versions of the same entity.
-* **In development**: Express multiple language string values within one document, tagging each string entry with its language.
 
 Additionally, developers who wish to write code in a language other than English can build a JSON-LD context file in their preferred language and then encounter badge property names familiar to them and their teams.
 


### PR DESCRIPTION
Per Issue 105# and the WGs decision on last weeks call, remove the bullet on in development multilingual badges. The examples section linked to already advises against using this technique (and instead recommends the technique in the bullet above), so AFAICS no further changes are needed.