### PR TITLE
Changed references of Badge Alliance to IMS Global

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Open Badges Specification
-This repository is the official location for the Open Badges Specification. See [the published documentation](https://openbadgespec.org) (v1.1) for information about the current Open Badges standard. The documentation is generated from the contents of this repository. Contribute pull requests here to suggest edits, and join the [Badge Alliance Standard Working Group](https://groups.google.com/forum/#!forum/openbadges-dev) to participate in the continuing development of the spec.
+This is the official code repository for the Open Badges Specification. See [the published documentation](https://openbadgespec.org) for information about the current Open Badges standard. The documentation is generated from the contents of this repository. Contribute pull requests here to suggest edits and participate in the continuing development of the spec.
 
 ## About Open Badges
 [Open Badges](http://openbadges.org) are visual symbols of accomplishments packed with verifiable metadata according to the Open Badges Specification. The Open Badges Specification defines the properties necessary to define an achievement and award it to a recipient, as well as procedures for verifying badge authenticity and “baking” badge information into portable image files.
 
-The Open Badges Specification was developed by the [Mozilla Foundation](http://mozillafoundation.org) with support from the [MacArthur Foundation](https://www.macfound.org/). The specification is managed by the [Badge Alliance](http://badgealliance.org)
+The Open Badges Specification was originally developed by the [Mozilla Foundation](http://mozillafoundation.org) with support from the [MacArthur Foundation](https://www.macfound.org/). The specification is managed by [IMS Global Learning Consortium](https://www.imsglobal.org/)


### PR DESCRIPTION
Updated mentions of Badge Alliance to refer to IMS Global