### PR TITLE
Resolves #156. Adds IssuerOrg alias to context.

### DIFF
--- a/v1/context.json
+++ b/v1/context.json
@@ -16,6 +16,7 @@
     "Assertion": "obi:Assertion",
     "BadgeClass": "obi:BadgeClass",
     "Issuer": "obi:Issuer",
+    "IssuerOrg": "obi:Issuer",
     "Extension": "obi:Extension",
     "hosted": "obi:HostedBadge",
     "signed": "obi:SignedBadge",


### PR DESCRIPTION
 At one point, the spec described an example of using this alias as the value for the  property of an Issuer Profile, and it has been implemented that way by several vendors.

This change properly sets the alias for this term so it resolves to be the same as "Issuer". Resolves #156.