### PR TITLE
Remove Achievement `type` property

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -24,7 +24,6 @@ Package Credentials DataModel
 
     Class Achievement Unordered false []                            "A collection of information about the accomplishment recognized by the Assertion. Many assertions may be created corresponding to one Achievement."
         Property id URI 1                                           "Unique URI for the Achievement. Required so the achievement can be the subject of an endorsement."
-        Property type IRI 1                                         "The type MUST be 'Achievement'".
         Property alignment Alignment 0..*                           "An object describing which objectives or educational standards this achievement aligns to, if any."
         Property achievementType AchievementType 0..1               "The type of achievement. This is an extensible vocabulary."
         Property creator Profile 0..1                               "The person or organization that created the achievement definition."


### PR DESCRIPTION
Achievement `type` is required in OB 2.0, so I added `type` to OB 3.0 Achievement, and made it required. This PR removes the Achievement `type` property.

Closes #429 