### PR TITLE
Rename `criterion` to `criteria`

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -29,7 +29,7 @@ Package Credentials DataModel
         Property achievementType AchievementType 0..1               "The type of achievement. This is an extensible vocabulary."
         Property creator Profile 0..1                               "The person or organization that created the achievement definition."
         Property creditsAvailable Float 0..1                        "Credit hours associated with this entity, or credit hours possible. For example 3.0."
-        Property criterion Criterion 1                              "Criterion document describing how to earn the achievement."
+        Property criteria Criteria 1                                "Criteria describing how to earn the achievement."
         Property description String 1                               "A short description of the achievement."
         Property endorsement EndorsementCredential 0..*             "Allows endorsers to make specific claims about the Achievement."
         Property fieldOfStudy String 0..1                           "Category, subject, area of study, discipline, or general branch of knowledge. Examples include Business, Education, Psychology, and Technology."
@@ -52,8 +52,8 @@ Package Credentials DataModel
         Property targetUrl URL 1                                    "URL linking to the official description of the alignment target, for example an individual standard within an educational framework."
         Mixin Extensions
 
-    Class Criterion Unordered false []                              "Descriptive metadata about the achievements necessary to be recognized with an assertion of a particular achievement. This data is added to the Achievement class so that it may be rendered when the achievement assertion is displayed, instead of simply a link to human-readable criteria external to the achievement. Embedding criteria allows either enhancement of an external criteria page or increased portability and ease of use by allowing issuers to skip hosting the formerly-required external criteria page altogether. Criteria is used to allow would-be recipients to learn what is required of them to be recognized with an assertion of a particular achievement. It is also used after the assertion is awarded to a recipient to let those inspecting earned achievements know the general requirements that the recipients met in order to earn it."
-        Property id URI 0..1                                        "The URI of a webpage that describes in a human-readable format the criterion for the achievement."
+    Class Criteria Unordered false []                               "Descriptive metadata about the achievements necessary to be recognized with an assertion of a particular achievement. This data is added to the Achievement class so that it may be rendered when the achievement assertion is displayed, instead of simply a link to human-readable criteria external to the achievement. Embedding criteria allows either enhancement of an external criteria page or increased portability and ease of use by allowing issuers to skip hosting the formerly-required external criteria page altogether. Criteria is used to allow would-be recipients to learn what is required of them to be recognized with an assertion of a particular achievement. It is also used after the assertion is awarded to a recipient to let those inspecting earned achievements know the general requirements that the recipients met in order to earn it."
+        Property id URI 0..1                                        "The URI of a webpage that describes in a human-readable format the criteria for the achievement."
         Property narrative Markdown 0..1                            "A narrative of what is needed to earn the achievement. Markdown is allowed."
         Mixin Extensions
 


### PR DESCRIPTION
The PR renames the `criterion` property and the `Criterion` class to `criteria` and `Criteria`.

The context already has `criteria` and `Criteria` so no change is need to context.json.

Closes #431 