### PR TITLE
Add missing `version` property

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -39,6 +39,7 @@ Package Credentials DataModel
         Mixin OtherIdentifiers                                      // From CDM
         Property specialization String 0..1                         "Name given to the focus, concentration, or specific area of study defined in the achievement. Examples include 'Entrepreneurship', 'Technical Communication', and 'Finance'."
         Property tag String 0..*                                    "Tags that describes the type of achievement."
+        Property version String 0..1                                "The version property allows issuers to set a version string for an Achievement. This is particularly useful when replacing a previous version with an update."
         Mixin Extensions
 
     Include Address                                                 // From CDM

--- a/ob_v3p0/context.json
+++ b/ob_v3p0/context.json
@@ -45,6 +45,10 @@
           "@id": "https://schema.org/keywords", 
           "@type": "xsd:string", 
           "@container": "@set"
+        },
+        "version": {
+          "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#version", 
+          "@type": "xsd:string"
         }
       }
     },


### PR DESCRIPTION
This PR adds the missing `version` property to the Achievement (nee BadgeClass) Data Model class and context.

In prior versions of the spec, the `version` property could be a string or a number, and it could be applied to any entity. This PR constraints the property value to a string and is only a member of the Achievement class.

```
{
  "type": ["Achievement"],
  "name": "Awesome Robotics Badge",
  "version": "1"
}
```

Closes #423 