### PR TITLE
Do not require `id` just for possible endorsement

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -4,7 +4,6 @@ Package Credentials DataModel
 
     Class AchievementCredential Unordered false [VerifiableCredential] "AchievementCredentials are representations of an awarded achievement, used to share information about a achievement belonging to one earner. Maps to a Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value 'https://www.w3.org/2018/credentials/v1', and the second item is a URI with the value 'https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld'."
-        Property id URI 1                                           "Unambiguous reference to the credential. Required so it can be the subject of an endorsement."
         Property type IRI 1..*                                      "The value of the type property MUST be an unordered set. One of the items MUST be the URI 'VerifiableCredential', and one of the items MUST be the URI 'AchievementCredential' or the URI 'OpenBadgeCredential'."
         Property name String 1                                      "The name of the credential for display purposes in wallets. For example, in a list of credentials and in detail views."
         Property description String 0..1                            "The short description of the credential for display purposes in wallets."
@@ -23,7 +22,7 @@ Package Credentials DataModel
         Property result Result 0..*                                 "The set of results being asserted."
 
     Class Achievement Unordered false []                            "A collection of information about the accomplishment recognized by the Assertion. Many assertions may be created corresponding to one Achievement."
-        Property id URI 1                                           "Unique URI for the Achievement. Required so the achievement can be the subject of an endorsement."
+        Property id URI 0..1                                        "Unique URI for the Achievement."
         Property type IRI 1                                         "The type MUST be 'Achievement'".
         Property alignment Alignment 0..*                           "An object describing which objectives or educational standards this achievement aligns to, if any."
         Property achievementType AchievementType 0..1               "The type of achievement. This is an extensible vocabulary."
@@ -82,7 +81,7 @@ Package Credentials DataModel
         Property caption String 0..1                                "The caption for the image."
 
     Class Profile Unordered false []                                "A Profile is a collection of information that describes the entity or organization using Open Badges. Issuers must be represented as Profiles, and recipients, endorsers, or other entities may also be represented using this vocabulary. Each Profile that represents an Issuer may be referenced in many BadgeClasses that it has defined. Anyone can create and host an Issuer file to start issuing Open Badges. Issuers may also serve as recipients of Open Badges, often identified within an Assertion by specific properties, like their url or contact email address."
-        Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
+        Property id URI 0..1                                        "Unique URI for the Issuer/Profile file."
         Property name String 0..1                                   "The name of the entity or organization."
         Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
         Mixin Phone                                                 // From CDM


### PR DESCRIPTION
The current data model requires the `AchievementCredential`, `Achievement`, and `Profile` classes have `id` property so they can be the subject (target) of an Endorsement.

This PR makes the `id` property of those 3 classes optional.

Closes #427, #428