### PR TITLE
Remove redundant properties from Profile class

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -94,10 +94,8 @@ Package Credentials DataModel
         Mixin OtherIdentifiers                                      // From CDM
         Property official String 0..1                               "If the entity is an organization, `official` is the name of an authorized official of the organization."
         Property parentOrg Profile 0..1                             "The parent organization of the entity."
-        Property sourcedId UUID 0..1                                "The sourcedId of the profile. This is the interoperability identifier that systems will refer to when making API calls, or when needing to identify an object. Systems SHOULD be able to map whichever local ids (e.g. database key fields) they use to sourcedId. The sourcedId of an object MUST be an anonymized or pseudonymized identifier of an entity and as such will not contain Personally Identifiable Information (PII) or Personal Data (PD)."
         Mixin PersonNameParts                                       // From CDM
         Property dateOfBirth Date 0..1                              ""Birthdate of the person."
-        Property sisSourcedId String 0..1                           "An institution's student identifier for the person. This is frequently issued through a Student Information System."
         Mixin Extensions
 
     Class Result Unordered false []                                 "Describes a result that was achieved."

--- a/ob_v3p0/context.json
+++ b/ob_v3p0/context.json
@@ -250,14 +250,6 @@
         "official": {
           "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#official",
           "@type": "xsd:string"
-        },
-        "sisSourcedId": {
-          "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#sisSourcedId",
-          "@type": "xsd:string"
-        },
-        "sourcedId": {
-          "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#sourcedId",
-          "@type": "xsd:string"
         }
       }
     },


### PR DESCRIPTION
`sourcedId` and `sisSourcedId` can be represented as `otherIdentifier`.

This PR removes `sourcedId` and `sisSourcedId` from the Profile class data model and context file.