### PR TITLE
Add support for VC-JWT signed endorsement credentials in an open badge credential

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -12,7 +12,7 @@ Package SharedCredentialDataModels DataModel
         Property criteria Criteria 1                                "Criteria describing how to earn the achievement."
         Property description String 1                               "A short description of the achievement."
         Property endorsement EndorsementCredential 0..*             "Allows endorsers to make specific claims about the Achievement. These endorsements are signed with a Data Integrity proof format."
-        Property jwsEndorsement CompactJws 0..*                     "Allows endorsers to make specific claims about the Achievement. These endorsements are signed with the VC-JWT proof format."
+        Property endorsementJwt CompactJws 0..*                     "Allows endorsers to make specific claims about the Achievement. These endorsements are signed with the VC-JWT proof format."
         Property fieldOfStudy String 0..1                           "Category, subject, area of study, discipline, or general branch of knowledge. Examples include Business, Education, Psychology, and Technology."
         Property humanCode String 0..1                              "The code, generally human readable, associated with an achievement."
         Property image Image 0..1                                   "An image representing the achievement."
@@ -35,7 +35,7 @@ Package SharedCredentialDataModels DataModel
         Property image Image 0..1                                   "The image representing the credential for display purposes in wallets."
         Property credentialSubject AchievementSubject 1             "The recipient of the achievement."
         Property endorsement EndorsementCredential 0..*             "Allows endorsers to make specific claims about the credential, and the achievement and profiles in the credential. These endorsements are signed with a Data Integrity proof format."
-        Property jwsEndorsement CompactJws 0..*                     "Allows endorsers to make specific claims about the credential, and the achievement and profiles in the credential. These endorsements are signed with the VC-JWT proof format."
+        Property endorsementJwt CompactJws 0..*                     "Allows endorsers to make specific claims about the credential, and the achievement and profiles in the credential. These endorsements are signed with the VC-JWT proof format."
         Property evidence Evidence 0..*                             "A description of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible."
         Mixin Extensions
 
@@ -119,7 +119,7 @@ Package SharedCredentialDataModels DataModel
         Mixin Phone                                                 // From CDM
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property endorsement EndorsementCredential 0..*             "Allows endorsers to make specific claims about the individual or organization represented by this profile. These endorsements are signed with a Data Integrity proof format."
-        Property jwsEndorsement CompactJws 0..*                     "Allows endorsers to make specific claims about the individual or organization represented by this profile. These endorsements are signed with the VC-JWT proof format."
+        Property endorsementJwt CompactJws 0..*                     "Allows endorsers to make specific claims about the individual or organization represented by this profile. These endorsements are signed with the VC-JWT proof format."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         Mixin Email                                                 // From CDM
         Property address Address 0..1                               "An address for the individual or organization."


### PR DESCRIPTION
EndorsementCredentials may have a VC-JWT proof which is a Compact JWS string. This was handled in CLR 1.0 by providing two endorsement properties: `endorsements` and `signedEndorsements`. `endorsements` used hosted verification and were therefore JSON objects. `signedEndorsements` using signed verification and were therefore Compact JWS strings.

This PR will add an `endorsementJwt` property with a type of CompactJws to hold EndorsementCredentials with a VC-JWT proof.