### PR TITLE
Add `NotStarted` ResultStatusType

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -275,6 +275,7 @@ Package SharedCredentialDataModels DataModel
         Property Enrolled Term 1                                    "The learner is enrolled in the activity described by the achievement."
         Property Failed Term 1                                      "The learner has unsuccessfully completed the achievement."
         Property InProgress Term 1                                  "The learner has started progress in the activity described by the achievement."
+        Property NotStarted Term 1                                  "The learner has no started progress in the activity described by the achievement. This is used to identify achievements that are planned."
         Property OnHold Term 1                                      "The learner has completed the activity described by the achievement, but successful completion has not been awarded, typically for administrative reasons."
         Property Withdrew Term 1                                    "The learner withdrew from the activity described by the achievement before completion."
 


### PR DESCRIPTION
This PR adds a new `NotStarted` ResultStatusType. Primary use case is a ClrCredential issuer wants to include all of the learner's achievements: planned, in progress, and completed so the learner and verifiers can assess their progress.

See related [PR #305](Dependent on [PR #456](https://github.com/IMSGlobal/openbadges-specification/pull/456) in the Open Badges repository.) in the ComprehensiveLearnerRecord repository.