### PR TITLE
Feature/extensions

### DIFF
--- a/extensions/assessmentExtension/v2p0/ob-assessment_v2p0.lines
+++ b/extensions/assessmentExtension/v2p0/ob-assessment_v2p0.lines
@@ -2,32 +2,33 @@ Model ob-assmt 2024-09-12 2.0 "s:IMS Base Document" "t:Open Badges Assessment Ex
 
 Package MainClasses DataModel
 
-    Class AssessmentResultDescription Unordered false [] "ResultDescription extension with assessment information"
-        Property description String 1 "d:Description of the single assessment."
-        Property assessmentType AssesmentTypeEnum 1 "d:Assessment type."
-        Property assessmentOutput String 1 "d:This field provides additional details about assessment type. Values for assessmentOutput are expected to be words or phrases that describe the key features of the evidence that are produced in earning the badge."
-        Property hasGroupParticipation Boolean 1 "d:Completing the assessment activity being referenced requires two or more participants."
-        Property hasGroupEvaluation Boolean 1 "d:Participants in the assessment activity being referenced are scored as a group."
-        Property evaluationMethod String 0..1 "d:Information about how the assessment is scored. What do the scores represent in a range of scores? If a rubric was used, what are the score ranges for each criteria?."
-        Property assessmentExample URI 0..1 "d:An example based on the assessment type."
-        Property scoringMethodExampleDescription String 0..1 "d:The text of an example of the method or tool used to score the assessment."
-        Property assessmentEvaluation URI 0..1 "d:Link to studies or other information about research or calculations of reliability and validity for the assessment or the scoring methods."
-        Property sections Section 0..* "d:A listing of sections, each with questions, that make up the assessment. Typically included if the issuer wishes to make available applications for the badge."
+    Class AssessmentResultDescription Unordered false []       "ResultDescription extension with assessment information"
+        Property description String 1                          "d:Description of the single assessment."
+        Property assessmentType AssesmentTypeEnum 1            "d:Assessment type."
+        Property assessmentOutput String 1                     "d:This field provides additional details about assessment type. Values for assessmentOutput are expected to be words or phrases that describe the key features of the evidence that are produced in earning the badge."
+        Property hasGroupParticipation Boolean 1               "d:Completing the assessment activity being referenced requires two or more participants."
+        Property hasGroupEvaluation Boolean 1                  "d:Participants in the assessment activity being referenced are scored as a group."
+        Property evaluationMethod String 0..1                  "d:Information about how the assessment is scored. What do the scores represent in a range of scores? If a rubric was used, what are the score ranges for each criteria?."
+        Property assessmentExample URI 0..1                    "d:An example based on the assessment type."
+        Property scoringMethodExampleDescription String 0..1   "d:The text of an example of the method or tool used to score the assessment."
+        Property assessmentEvaluation URI 0..1                 "d:Link to studies or other information about research or calculations of reliability and validity for the assessment or the scoring methods."
+        Property sections Section 0..*                         "d:A listing of sections, each with questions, that make up the assessment. Typically included if the issuer wishes to make available applications for the badge."
 
     Class Section Unordered false []
-        Property title String 1 "d:The name of the section."
-        Property description String 1 "d:A short description of the section."
-        Property questions Question 0..* "d:The questions that make up this section."
-        Property required String 0..1 "d:Indicates whether this section is considered to be required for completion of the assessment. Default: true."
-        Property url URI 0..1 "d:An external URL that represents this section."
+        Property type IRI 1                 "d:MUST be the IRI 'Section'."
+        Property title String 1             "d:The name of the section."
+        Property description String 1       "d:A short description of the section."
+        Property questions Question 0..*    "d:The questions that make up this section."
+        Property required String 0..1       "d:Indicates whether this section is considered to be required for completion of the assessment. Default: true."
+        Property url URI 0..1               "d:An external URL that represents this section."
 
     Class Question Unordered false []
-        Property type IRI 1 "d:The type of question. One of the following type identifiers defined in the extension context: 'ExternalQuestion', 'FileQuestion' or 'TextQuestion'."
-        Property text String 1 "d:The actual text of the question."
-        Property required String 0..1 "d:Indicates whether this question is considered to be required for completion of the section. Default: true."
-        Property wordLimit NonNegativeInteger 0..1 "d:For TextQuestions, specifies a maximum length in words that may be enforced as a suggestion or requirement, depending on the application."
+        Property type IRI 1                             "d:The type of question. One of the following type identifiers defined in the extension context: 'ExternalQuestion', 'FileQuestion' or 'TextQuestion'."
+        Property text String 1                          "d:The actual text of the question."
+        Property required String 0..1                   "d:Indicates whether this question is considered to be required for completion of the section. Default: true."
+        Property wordLimit NonNegativeInteger 0..1      "d:For TextQuestions, specifies a maximum length in words that may be enforced as a suggestion or requirement, depending on the application."
         Property characterLimit NonNegativeInteger 0..1 "d:For TextQuestions, specifies a maximum length in characters that may be enforced as a suggestion or requirement, depending on the application."
-        Property url URI 0..1 "d:An external URL that represents this question."
+        Property url URI 0..1                           "d:An external URL that represents this question."
 
 Package Enumerations DataModel
 

--- a/extensions/issuerAccreditationExtension/v2p0/ob-accred_v2p0.lines
+++ b/extensions/issuerAccreditationExtension/v2p0/ob-accred_v2p0.lines
@@ -5,11 +5,12 @@ Package MainClasses DataModel
     Class IssuerAccreditationProfile Unordered false [] "Profile extension with accreditation information."
         Property accreditations AccreditationProfile 0..1 "d:listing of accreditations."
 
-    Class AccreditationProfile Unordered false [] "Profile extension with detailed information about an accrediting organization."
-        Property contactInstructions String 1 "d:Contact instructions for an accrediting organization."
-        Property areaServed String 0..1 "d:The geographic area where accreditation services are targeted."
-        Property accreditationDate DateTimeZ 0..1 "d:The date accreditation was valid"
-        Property educationSector String 0..1 "d:Focus of accreditation (ex: K12, Postsecondary, CTE, Workforce, Adult Ed)."
+    Class AccreditationProfile Unordered false []   "Profile extension with detailed information about an accrediting organization."
+        Property type IRI 1                         "d:MUST be the IRI 'AccreditationProfile'."
+        Property contactInstructions String 1       "d:Contact instructions for an accrediting organization."
+        Property areaServed String 0..1             "d:The geographic area where accreditation services are targeted."
+        Property accreditationDate DateTimeZ 0..1   "d:The date accreditation was valid"
+        Property educationSector String 0..1        "d:Focus of accreditation (ex: K12, Postsecondary, CTE, Workforce, Adult Ed)."
 
 // Core OB types, defined here only for JSON Schema generation
 Package OBClasses DataModel
@@ -29,7 +30,7 @@ Package OBSupportClasses DataModel
 
 Package DerivedTypes DataModel
 
-    Includes [URI]
+    Includes [IRI, URI]
 
 
 // PrimitiveTypes

--- a/extensions/issuerAccreditationExtension/v2p0/ob-accred_v2p0.lines
+++ b/extensions/issuerAccreditationExtension/v2p0/ob-accred_v2p0.lines
@@ -7,7 +7,6 @@ Package MainClasses DataModel
 
     Class AccreditationProfile Unordered false [] "Profile extension with detailed information about an accrediting organization."
         Property contactInstructions String 1 "d:Contact instructions for an accrediting organization."
-        Property logo URI 0..1 "d:The logo for the accrediting organization."
         Property areaServed String 0..1 "d:The geographic area where accreditation services are targeted."
         Property accreditationDate DateTimeZ 0..1 "d:The date accreditation was valid"
         Property educationSector String 0..1 "d:Focus of accreditation (ex: K12, Postsecondary, CTE, Workforce, Adult Ed)."


### PR DESCRIPTION
This pull request includes several updates to the data model in the `extensions` directory, specifically for the `assessmentExtension` and `issuerAccreditationExtension` packages. The most important changes include adding required properties, removing unnecessary properties, and updating included types.

### Updates to `assessmentExtension`:

* [`extensions/assessmentExtension/v2p0/ob-assessment_v2p0.lines`](diffhunk://#diff-fbe9128e1edada0bf0a725d2ee0ee6a6b8bfe50e3480c8627b072ba35548fdb7R18): Added `type` property to the `Section` class, which must be the IRI 'Section'.

### Updates to `issuerAccreditationExtension`:

* [`extensions/issuerAccreditationExtension/v2p0/ob-accred_v2p0.lines`](diffhunk://#diff-5a6495fb0b3fd8807cad17ee74f445abcc70d1b6406dbe096ed63d73dbee4d7fR9-L10): Added `type` property to the `AccreditationProfile` class, which must be the IRI 'AccreditationProfile'.
* [`extensions/issuerAccreditationExtension/v2p0/ob-accred_v2p0.lines`](diffhunk://#diff-5a6495fb0b3fd8807cad17ee74f445abcc70d1b6406dbe096ed63d73dbee4d7fR9-L10): Removed the `logo` property from the `AccreditationProfile` class.
* [`extensions/issuerAccreditationExtension/v2p0/ob-accred_v2p0.lines`](diffhunk://#diff-5a6495fb0b3fd8807cad17ee74f445abcc70d1b6406dbe096ed63d73dbee4d7fL33-R33): Updated `Includes` to include both `IRI` and `URI`.