### PR TITLE
Feature/sd2023

### DIFF
--- a/ob_v3p0/cert/displayer.md
+++ b/ob_v3p0/cert/displayer.md
@@ -44,5 +44,6 @@ Open Badges Verifiers must support the following supported proof mechanisms for
 Linked Data Proof format:
 
 - [[[VC-DI-EDDSA]]] suite with the \`eddsa-rdfc-2022\` algorithm.
+- [[[VC-DI-ECDSA]]] suite with the \`ecdsa-sd-2023\` algorithm.
 
 `;

--- a/ob_v3p0/cert/issuer.md
+++ b/ob_v3p0/cert/issuer.md
@@ -21,6 +21,7 @@ Open Badges Issuers opting for a Linked Data Proof format as the signature of
 the badge must use one of the following supported proof mechanisms:
 
 - [[[VC-DI-EDDSA]]] suite with the \`eddsa-rdfc-2022\` algorithm.
+- [[[VC-DI-ECDSA]]] suite with the \`ecdsa-sd-2023\` algorithm. The resulting credential MUST contain all required fields for the credential.
 
 ### Service Consumer (Write) Conformance {#service-consumer-write}
 

--- a/ob_v3p0/cert/ob-cert-v3p0.html
+++ b/ob_v3p0/cert/ob-cert-v3p0.html
@@ -23,9 +23,9 @@
             specNature: "normative", // spec nature is "normative" or "informative"
             specType: "cert", // spec type is "main", "cert", "impl", "errata" or other agreed upon string
             specVersion: "3.0",
-            docVersion: "1.1",
+            docVersion: "1.2",
             specStatus: "Final Release",
-            specDate: "Dec 23, 2024",
+            specDate: "July 11, 2025",
             contributors: _contributors,
             localBiblio: _localBiblio,
             iprs: _iprs,
@@ -107,6 +107,15 @@
                         </ul>
                     </td>
                 </tr>
+                <tr>
+                    <td>Final</td>
+                    <td>1.2</td>
+                    <td>July 11, 2025</td>
+                    <td>
+                        Added ECDSA Cryptosuite <code>ecdsa-sd-2023</code> to Issuer and Displayer supported proof mechanisms.
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </section>


### PR DESCRIPTION
This pull request introduces support for the new `ecdsa-sd-2023` cryptosuite in the Open Badges specification and updates the documentation to reflect this addition. The changes also include a version update for the specification document and an entry in the revision history to highlight the new feature.

### Support for new cryptosuite:
* [`ob_v3p0/cert/displayer.md`](diffhunk://#diff-81a778bcb0678369ba6fd7e2d02ae06cbec4ec6b0fe699ca8d719db974a23abaR47): Added the `ecdsa-sd-2023` algorithm to the list of supported proof mechanisms for Open Badges Verifiers.
* [`ob_v3p0/cert/issuer.md`](diffhunk://#diff-5713db147c17ea7cf88229735e462f643bfe8c958dd13899c2f7b22c05b37e05R24): Added the `ecdsa-sd-2023` algorithm to the list of supported proof mechanisms for Open Badges Issuers, with a requirement to include all necessary fields in the resulting credential.

### Documentation updates:
* [`ob_v3p0/cert/ob-cert-v3p0.html`](diffhunk://#diff-1b5dfb74d07c7575f60bb4f459c9faba2d717fec59b653fd6bbc9166b725dd90L26-R28): Updated the document version to `1.2` and the specification date to `July 11, 2025`.
* [`ob_v3p0/cert/ob-cert-v3p0.html`](diffhunk://#diff-1b5dfb74d07c7575f60bb4f459c9faba2d717fec59b653fd6bbc9166b725dd90R110-R118): Added a new entry in the revision history to document the addition of the `ecdsa-sd-2023` cryptosuite for Issuers and Verifiers.