### PR TITLE
Develop update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openbadges-specification
 ## Specification documents related to Open Badges
-The published version of Open Badges 2.0 is in main and develop. Version 2.1 is only in develop until Final.
+The published version of Open Badges 3.0 is in main and develop. Version 2.1 is only in develop until Final. Version 2.0 is in main and develop.
 
 ## Proposals
 For information about how to propose a new feature or material change to the specification, please see `proposals/README.md`.

--- a/extensions/assessmentExtension/v2p0/index.html
+++ b/extensions/assessmentExtension/v2p0/index.html
@@ -21,8 +21,8 @@
     var respecConfig = {
       specTitle: "Open Badges Assessment Extension",
       shortName: "ob-assessment",
-      specStatus: "Base Document",
-      specDate: "July 24th, 2024",
+      specStatus: "Candidate Final Public",
+      specDate: "July 8th, 2025",
       specNature: "normative",
       specVersion: "2.0",
       specType: "spec",
@@ -295,6 +295,11 @@
             <td>Working Document 1.0</td>
             <td>July 24th, 2024</td>
             <td>Initial proof of concept.</td>
+          </tr>
+          <tr>
+            <td>Candidate Final Public 1.0</td>
+            <td>July 8th, 2025</td>
+            <td>Candidate Final Public version.</td>
           </tr>
         </tbody>
       </table>

--- a/ob_v3p0/cert/displayer.md
+++ b/ob_v3p0/cert/displayer.md
@@ -44,5 +44,6 @@ Open Badges Verifiers must support the following supported proof mechanisms for
 Linked Data Proof format:
 
 - [[[VC-DI-EDDSA]]] suite with the \`eddsa-rdfc-2022\` algorithm.
+- [[[VC-DI-ECDSA]]] suite with the \`ecdsa-sd-2023\` algorithm.
 
 `;

--- a/ob_v3p0/cert/issuer.md
+++ b/ob_v3p0/cert/issuer.md
@@ -21,6 +21,7 @@ Open Badges Issuers opting for a Linked Data Proof format as the signature of
 the badge must use one of the following supported proof mechanisms:
 
 - [[[VC-DI-EDDSA]]] suite with the \`eddsa-rdfc-2022\` algorithm.
+- [[[VC-DI-ECDSA]]] suite with the \`ecdsa-sd-2023\` algorithm. The resulting credential MUST contain all required fields for the credential.
 
 ### Service Consumer (Write) Conformance {#service-consumer-write}
 

--- a/ob_v3p0/cert/ob-cert-v3p0.html
+++ b/ob_v3p0/cert/ob-cert-v3p0.html
@@ -23,9 +23,9 @@
             specNature: "normative", // spec nature is "normative" or "informative"
             specType: "cert", // spec type is "main", "cert", "impl", "errata" or other agreed upon string
             specVersion: "3.0",
-            docVersion: "1.1",
+            docVersion: "1.2",
             specStatus: "Final Release",
-            specDate: "Dec 23, 2024",
+            specDate: "July 11, 2025",
             contributors: _contributors,
             localBiblio: _localBiblio,
             iprs: _iprs,
@@ -107,6 +107,15 @@
                         </ul>
                     </td>
                 </tr>
+                <tr>
+                    <td>Final</td>
+                    <td>1.2</td>
+                    <td>July 11, 2025</td>
+                    <td>
+                        Added ECDSA Cryptosuite <code>ecdsa-sd-2023</code> to Issuer and Displayer supported proof mechanisms.
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </section>

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -254,8 +254,7 @@ Package SharedCredentialDataModels DataModel
 
     Class Context EmbeddedSelection false [URI, Map]                "JSON-LD Context. Either a URI with the context definition or a Map with a local context definition MUST be supplied."
 
-    Class Map Unordered false []                                "A map representing an object with unknown, arbitrary properties"
-        Mixin Extensions
+    Class Map PrimitiveType false []                                "A map representing an object with unknown, arbitrary properties"
 
     // Enumerations
 

--- a/ob_v3p0/errata/errata.md
+++ b/ob_v3p0/errata/errata.md
@@ -70,5 +70,5 @@ algorithm to use in Open Badges. Concretely, it stated:
 > In order to opt for this format you MUST use the [[[VC-DI-EDDSA]]] suite.
 
 This statement may not follow the security requirements of the future as
-the securing mechanisms evolve over time. Therefore, the especific list of
-allowed proof format have been extracted out the [[[OB-CERT-30]]].
+the securing mechanisms evolve over time. Therefore, the specific list of
+allowed proof formats have been extracted out the [[[OB-CERT-30]]].

--- a/ob_v3p0/errata/ob_err_v3p0.html
+++ b/ob_v3p0/errata/ob_err_v3p0.html
@@ -37,7 +37,7 @@
                 specNature: 'informative', // spec nature is "normative" or "informative"
                 specType: 'errata', // spec type is "main", "cert", "impl", "errata" or other agreed upon string
                 specVersion: '3.0',
-                docVersion: '1.1',
+                docVersion: '1.3',
                 specStatus: "Final Release",
                 specDate: 'July 17, 2024',
                 contributors: _contributors,
@@ -98,6 +98,14 @@
                                 <li>Clarified proof mechanism and algorithm selection.</li>
                             </ul>
 
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Version 3.0 Final</td>
+                        <td>1.3</td>
+                        <td>June 16, 2025</td>
+                        <td>
+                            Fixed typography errors in the errata document.
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
This pull request updates multiple Open Badges specification documents and related files to introduce support for a new cryptographic proof mechanism, update versioning and release dates, and fix minor typographical errors. The most significant changes are the addition of the ECDSA cryptosuite for issuers and verifiers, updates to document versions and release dates, and corrections in documentation.

**Cryptographic Proof Mechanisms:**

* Added support for the ECDSA cryptosuite (`ecdsa-sd-2023`) as a valid proof mechanism for both issuers and verifiers in the Open Badges 3.0 certification documentation. This includes updates to both the issuer and displayer requirements and is reflected in the revision history. [[1]](diffhunk://#diff-81a778bcb0678369ba6fd7e2d02ae06cbec4ec6b0fe699ca8d719db974a23abaR47) [[2]](diffhunk://#diff-5713db147c17ea7cf88229735e462f643bfe8c958dd13899c2f7b22c05b37e05R24) [[3]](diffhunk://#diff-1b5dfb74d07c7575f60bb4f459c9faba2d717fec59b653fd6bbc9166b725dd90R110-R118)

**Documentation Versioning and Release Dates:**

* Updated the Open Badges 3.0 certification document to version 1.2 and changed the release date to July 11, 2025.
* Updated the errata document to version 1.3, with a new revision entry dated June 16, 2025. [[1]](diffhunk://#diff-9554f533ae01d1060a5df78ba4f22e3e9b151eebc2db61ed176d9021fba6648dL40-R40) [[2]](diffhunk://#diff-9554f533ae01d1060a5df78ba4f22e3e9b151eebc2db61ed176d9021fba6648dR103-R110)
* Updated the Assessment Extension specification status to "Candidate Final Public" and changed the release date to July 8th, 2025, with a corresponding entry in the version history. [[1]](diffhunk://#diff-32fbba9ea62f97376bbb34a9a42c8e3a81541a3877dcec8e1ef336b9b4a17121L24-R25) [[2]](diffhunk://#diff-32fbba9ea62f97376bbb34a9a42c8e3a81541a3877dcec8e1ef336b9b4a17121R299-R303)

**General Documentation Updates:**

* Clarified the README to indicate that Open Badges 3.0 is now published in both `main` and `develop` branches, and clarified the status of older versions.
* Fixed typographical errors in the errata documentation, specifically in the explanation of proof formats. [[1]](diffhunk://#diff-ffddaec64472efe7fe627622ea6c002351cc67aca1f49e29ec72e9368a883d75L73-R74) [[2]](diffhunk://#diff-9554f533ae01d1060a5df78ba4f22e3e9b151eebc2db61ed176d9021fba6648dR103-R110)

**Data Model Adjustments:**

* Changed the definition of the `Map` class in the shared credential data models to be a primitive type and removed the `Extensions` mixin.