### PR TITLE
634 ob3 openapi pagination link expressions use requestpath instead of requestquery for limitoffset

### DIFF
--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -34,13 +34,13 @@ var api = `
     <ul>
         <li>
             <a
-                href="https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json"
+                href="https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json"
                 >JSON OpenAPI File</a
             >
         </li>
         <li>
             <a
-                href="https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml"
+                href="https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml"
                 >YAML OpenAPI File</a
             >
         </li>

--- a/ob_v3p0/cert/introduction.md
+++ b/ob_v3p0/cert/introduction.md
@@ -10,8 +10,8 @@ The full set of documents is comprised of the following documents:
 
 -   [[[OB-30]]]
 -   [[[OB-CERT-30]]]
--   [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
--   [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+-   [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+-   [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 -   [Open Badges 3.0 JSON-LD Context File](https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json)
 
 ### Terms

--- a/ob_v3p0/cert/ob-cert-v3p0.html
+++ b/ob_v3p0/cert/ob-cert-v3p0.html
@@ -23,9 +23,9 @@
             specNature: "normative", // spec nature is "normative" or "informative"
             specType: "cert", // spec type is "main", "cert", "impl", "errata" or other agreed upon string
             specVersion: "3.0",
-            docVersion: "1.4",
+            docVersion: "1.5",
             specStatus: "Final Release",
-            specDate: "April 17, 2026",
+            specDate: "June 15, 2026",
             contributors: _contributors,
             localBiblio: _localBiblio,
             iprs: _iprs,
@@ -131,7 +131,17 @@
                         Updated revocation mechanism in Displayer certification profile.
                     </td>
                 </tr>
-            </tbody>
+                <tr>
+                    <td>Final</td>
+                    <td>1.5</td>
+                    <td>June 15, 2026</td>
+                    <td>
+                        <ul>
+                            <li>Fixed errors in OpenAPI files.</li>
+                        </ul>
+                    </td>
+                </tr>
+                </tbody>
         </table>
     </section>
 </body>

--- a/ob_v3p0/errata/errata.md
+++ b/ob_v3p0/errata/errata.md
@@ -81,3 +81,15 @@ Section [B.4.1 Service Description Document](https://www.imsglobal.org/spec/ob/v
 contains an extra `provided` in its description:
 
 > ...profiled version of the OpenAPI 3.0 (JSON) file _provided provided_ with this specification...
+
+### Open API definition Errors
+
+The inital version of the Open API definition file contained several errors:
+
+- Pagination link expressions use `$request.path` instead of `$request.query`
+- Schema for `@context` items uses oneOf with two string branches.
+
+These error were fixed at the new version of the documents:
+
+- [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+- [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)

--- a/ob_v3p0/errata/ob_err_v3p0.html
+++ b/ob_v3p0/errata/ob_err_v3p0.html
@@ -37,9 +37,9 @@
                 specNature: 'informative', // spec nature is "normative" or "informative"
                 specType: 'errata', // spec type is "main", "cert", "impl", "errata" or other agreed upon string
                 specVersion: '3.0',
-                docVersion: '1.4',
+                docVersion: '1.5',
                 specStatus: "Final Release",
-                specDate: 'February 25, 2026',
+                specDate: 'June 12, 2026',
                 contributors: _contributors,
                 localBiblio: _localBiblio
             }
@@ -114,6 +114,14 @@
                         <td>February 25, 2026</td>
                         <td>
                             Added typography errors in the errata document.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Version 3.0 Final</td>
+                        <td>1.5</td>
+                        <td>June 12, 2026</td>
+                        <td>
+                            Added OpenAPI definition errors.
                         </td>
                     </tr>
                 </tbody>

--- a/ob_v3p0/errata/ob_err_v3p0.html
+++ b/ob_v3p0/errata/ob_err_v3p0.html
@@ -19,11 +19,11 @@
         <!-- Load the MPS configuration -->
         <script class="remove" src="../mps-config.js"></script>
 
-        <!-- Load ajv2019 (Another JSON Schema Validator) if you want your examples validated -->
+        <!-- Load ajv2020 (Another JSON Schema Validator) if you want your examples validated -->
         <script
             class="remove"
-            src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.11.0/ajv2019.bundle.min.js"
-            integrity="sha512-C+5LzjYlC8qhPFniPXiod8efyXJ3fDRCUS87L8o8z5CGt/1LHflMozW6py7s16Z+TJy52C9teuDUq6iq2Nft7A=="
+            src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.17.1/ajv2020.bundle.min.js"
+            integrity="sha512-mXlpzWzZB+t4DFFezQkpSiCbT8aW12t688aLsd6KGNbRWDOdCur5C6Fl0rDl75VruBy42GvWsd6F35VQcs3lwQ=="
             crossorigin="anonymous"
             referrerpolicy="no-referrer"
         ></script>

--- a/ob_v3p0/impl/getting-started.md
+++ b/ob_v3p0/impl/getting-started.md
@@ -617,6 +617,6 @@ token grants, and protected resource endpoint access.
 
 ### Supporting Technical Resources
 
--   [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
--   [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+-   [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+-   [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 -   [Open Badges 3.0 JSON-LD Context File](https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json)

--- a/ob_v3p0/impl/ob_impl_v3p0.html
+++ b/ob_v3p0/impl/ob_impl_v3p0.html
@@ -37,9 +37,9 @@
                 specNature: 'informative', // spec nature is "normative" or "informative"
                 specType: 'impl', // spec type is "main", "cert", "impl", "errata" or other agreed upon string
                 specVersion: '3.0',
-                docVersion: '2.0',
+                docVersion: '2.1',
                 specStatus: 'Final Release',
-                specDate: 'Apr 7th, 2025',
+                specDate: 'June 15th, 2026',
                 contributors: _contributors,
                 localBiblio: _localBiblio,
                 iprs: _iprs,
@@ -277,7 +277,17 @@
                             </ul>
                         </td>
                     </tr>
-                </tbody>
+                    <tr>
+                        <td>Final</td>
+                        <td>2.1</td>
+                        <td>June 15, 2026</td>
+                        <td>
+                            <ul>
+                                <li>Fixed errors in OpenAPI files.</li>
+                            </ul>
+                        </td>
+                    </tr>
+                    </tbody>
             </table>
         </section>
     </body>

--- a/ob_v3p0/introduction.md
+++ b/ob_v3p0/introduction.md
@@ -24,8 +24,8 @@ The Open Badges Specification has several related documents and artifacts shown 
 >
 > -- [[[OPENAPIS]]]
 
--   [JSON OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
--   [YAML OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+-   [JSON OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+-   [YAML OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 
 #### JSON-LD Context File
 

--- a/ob_v3p0/microsites/v3p0.md
+++ b/ob_v3p0/microsites/v3p0.md
@@ -4,7 +4,7 @@ category: Specification
 title: Open Badges Specification
 shortcode: OB-30
 status: Final
-lastUpdated: 2025-11-06
+lastUpdated: 2026-06-15
 version: '3.0'
 nature: normative
 docType: specification
@@ -216,6 +216,10 @@ releases:
     docVersion: "1.4.3"
     date: 2026-04-22
     comments: "Fixed links to OpenAPI files in <a href=\"#api\">Open Badges API</a> section"
+  - version: "Final"
+    docVersion: "1.4.4"
+    date: 2026-06-15
+    comments: "Fixed errors in OpenAPI files"
 resources:
   - standards/v3p0/spec/spec-resources.md
 ---
@@ -242,8 +246,8 @@ The API defined here is intended for [=Clients=] and [=servers=] that give indiv
 
 In addition to the documentation in this section, there are [OpenAPI](#docs-openapi) files for the Open Badges API in both JSON and YAML format:
 
-* [JSON OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
-* [YAML OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+* [JSON OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+* [YAML OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 
 ### Architecture
 

--- a/ob_v3p0/microsites/v3p0/cert.md
+++ b/ob_v3p0/microsites/v3p0/cert.md
@@ -4,7 +4,7 @@ category: Certification
 title: Open Badges Specification Conformance and Certification Guide
 shortcode: OB-CERT-30
 status: Final
-lastUpdated: 2025-12-12
+lastUpdated: 2026-06-15
 version: '3.0'
 nature: normative
 docType: conformance
@@ -196,6 +196,14 @@ releases:
     docVersion: 1.3
     date: 2025-12-12
     comments: Added JSON-LD Safe mode requirement for issuer certification profile.
+  - version: Final
+    docVersion: 1.4
+    date: 2026-04-17
+    comments: Updated revocation mechanism in Displayer certification profile.
+  - version: Final
+    docVersion: 1.5
+    date: 2026-06-15
+    comments: Fixed errors in OpenAPI files.
 ---
 
 @standards/v3p0/cert/abstract.md

--- a/ob_v3p0/microsites/v3p0/cert/introduction.md
+++ b/ob_v3p0/microsites/v3p0/cert/introduction.md
@@ -17,8 +17,8 @@ The full set of documents is comprised of the following documents:
 
 - [[OB-30]]
 - [[OB-CERT-30]]
-- [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
-- [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+- [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+- [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 - [Open Badges 3.0 JSON-LD Context File](https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json)
 
 ### Terms

--- a/ob_v3p0/microsites/v3p0/errata.md
+++ b/ob_v3p0/microsites/v3p0/errata.md
@@ -4,7 +4,7 @@ category: Specification
 title: Open Badges Errata
 shortcode: OB-ERRATA-30
 status: Final
-lastUpdated: 2024-07-17
+lastUpdated: 2026-06-12
 version: '3.0'
 nature: informative
 docType: errata
@@ -123,6 +123,14 @@ releases:
     docVersion: 1.3
     date: 2025-06-16
     comments: Fixed typography errors in the errata document.
+  - version: Version 3.0 Final
+    docVersion: 1.4
+    date: 2026-02-25
+    comments: Fixed typography errors in the errata document.
+  - version: Version 3.0 Final
+    docVersion: 1.5
+    date: 2026-06-12
+    comments: Added OpenAPI definition errors.
 ---
 
 @standards/v3p0/errata/errata.md

--- a/ob_v3p0/microsites/v3p0/errata/errata.md
+++ b/ob_v3p0/microsites/v3p0/errata/errata.md
@@ -81,3 +81,15 @@ algorithm to use in Open Badges. Concretely, it stated:
 This statement may not follow the security requirements of the future as
 the securing mechanisms evolve over time. Therefore, the specific list of
 allowed proof formats have been extracted out the [[OB-CERT-30]].
+
+### Open API definition Errors
+
+The inital version of the Open API definition file contained several errors:
+
+- Pagination link expressions use `$request.path` instead of `$request.query`
+- Schema for `@context` items uses oneOf with two string branches.
+
+These error were fixed at the new version of the documents:
+
+- [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+- [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)

--- a/ob_v3p0/microsites/v3p0/impl.md
+++ b/ob_v3p0/microsites/v3p0/impl.md
@@ -4,7 +4,7 @@ category: Guide
 title: Open Badges Implementation Guide
 shortcode: OB-IMPL-30
 status: Final
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-15
 version: '3.0'
 nature: informative
 docType: guide
@@ -156,6 +156,10 @@ releases:
     docVersion: 2.0
     date: 2025-04-07
     comments: Fixed some typos.
+  - version: Final Release
+    docVersion: 2.1
+    date: 2026-06-15
+    comments: Fixed errors in OpenAPI files.
 ---
 
 @standards/v3p0/impl/introduction.md

--- a/ob_v3p0/microsites/v3p0/impl/getting-started.md
+++ b/ob_v3p0/microsites/v3p0/impl/getting-started.md
@@ -634,6 +634,6 @@ token grants, and protected resource endpoint access.
 
 ### Supporting Technical Resources
 
--   [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
--   [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+-   [OpenAPI 3.0 JSON File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+-   [OpenAPI 3.0 YAML File for Open Badges API](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 -   [Open Badges 3.0 JSON-LD Context File](https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json)

--- a/ob_v3p0/microsites/v3p0/spec/introduction.md
+++ b/ob_v3p0/microsites/v3p0/spec/introduction.md
@@ -31,8 +31,8 @@ The Open Badges Specification has several related documents and artifacts shown 
 >
 > -- [[OPENAPIS]]
 
--   [JSON OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
--   [YAML OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+-   [JSON OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+-   [YAML OpenAPI File](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 
 ### JSON-LD Context File
 

--- a/ob_v3p0/microsites/v3p0/spec/spec-resources.md
+++ b/ob_v3p0/microsites/v3p0/spec/spec-resources.md
@@ -29,8 +29,8 @@ description: >
 
 The service model is available as an OpenAPI document at the following URL:
 
-- [https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.json)
-- [https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_oas.yaml)
+- [https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.json)
+- [https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml](https://purl.imsglobal.org/spec/ob/v3p0/schema/openapi/ob_v3p0_openapi3_v1p0p1.yaml)
 
 ### Skill
 

--- a/ob_v3p0/ob_v3p0.html
+++ b/ob_v3p0/ob_v3p0.html
@@ -27,9 +27,9 @@
       specNature: "normative", // spec nature is "normative" or "informative"
       specType: "main", // spec type is "main", "cert", "impl", "errata" or other agreed upon string
       specVersion: "3.0",
-      docVersion: "1.4.3",
+      docVersion: "1.4.4",
       specStatus: "Final Release",
-      specDate: "April 22, 2026",
+      specDate: "June 15, 2026",
       contributors: _contributors,
       localBiblio: _localBiblio,
       iprs: _iprs,
@@ -267,6 +267,16 @@
           <td>
             <ul>
                 <li>Fixed links to OpenAPI files in <a href="#api">Open Badges API</a> section</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>Final</td>
+          <td>1.4.4</td>
+          <td>June 15, 2026</td>
+          <td>
+            <ul>
+                <li>Fixed errors in OpenAPI files.</li>
             </ul>
           </td>
         </tr>

--- a/ob_v3p0/ob_v3p0.html
+++ b/ob_v3p0/ob_v3p0.html
@@ -13,9 +13,9 @@
   <!-- Load the MPS configuration -->
   <script class="remove" src="mps-config.js"></script>
 
-  <!-- Load ajv2019 (Another JSON Schema Validator) if you want your examples validated -->
-  <script class="remove" src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.11.0/ajv2019.bundle.min.js"
-          integrity="sha512-C+5LzjYlC8qhPFniPXiod8efyXJ3fDRCUS87L8o8z5CGt/1LHflMozW6py7s16Z+TJy52C9teuDUq6iq2Nft7A=="
+  <!-- Load ajv2020 (Another JSON Schema Validator) if you want your examples validated -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.17.1/ajv2020.bundle.min.js"
+          integrity="sha512-mXlpzWzZB+t4DFFezQkpSiCbT8aW12t688aLsd6KGNbRWDOdCur5C6Fl0rDl75VruBy42GvWsd6F35VQcs3lwQ=="
           crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
   <script class='remove'>


### PR DESCRIPTION
This pull request updates the Open Badges 3.0 documentation to address errors in the OpenAPI definition files and to reference their corrected versions throughout the specification. It also updates the errata and release history to reflect these changes, and upgrades the JSON Schema validator used in the HTML documentation from `ajv2019` to `ajv2020`.

**OpenAPI Definition Corrections:**

* Added errata entries documenting previously existing errors in the OpenAPI definition files (incorrect pagination link expressions and schema issues), and referenced the new, corrected OpenAPI 3.0 JSON and YAML files. [[1]](diffhunk://#diff-ffddaec64472efe7fe627622ea6c002351cc67aca1f49e29ec72e9368a883d75R84-R95) [[2]](diffhunk://#diff-c41a15c6d7b5523b23b8fa3e76c3eb444007be2e99b5b5a9d086b11404b2cd06R84-R95)
* Updated all references to the OpenAPI 3.0 definition files in the documentation to point to the corrected files (`ob_v3p0_openapi3_v1p0p1.json` and `.yaml`). [[1]](diffhunk://#diff-3e9e65662479b17d576753992f9e267fbb2c6ec782725d0fb652e37be6f99cb5L20-R21) [[2]](diffhunk://#diff-f05fc2b9ce9ad1c811ef79097e469bf87dab9436b3f24db98f6ba7bf52a2c267L637-R638) [[3]](diffhunk://#diff-e6506a40af19eef91107796d3887fdf5cc07f25a50e4aa4d13d02485f61f9ef3L34-R35) [[4]](diffhunk://#diff-cb58ca34a49dca6fcf0f7c5a3f3302a4c2d31346cf82fb83f7e09eddc3348f49L32-R33)

**Documentation and Release History Updates:**

* Updated the release history and metadata in the errata documentation to reflect the new version (1.5, June 12, 2026) and the addition of OpenAPI definition errors. [[1]](diffhunk://#diff-44a7ecbb36e746825723ae53b44733e3e60978318c2786e75d801308fbfa0b02L7-R7) [[2]](diffhunk://#diff-44a7ecbb36e746825723ae53b44733e3e60978318c2786e75d801308fbfa0b02R126-R133) [[3]](diffhunk://#diff-9554f533ae01d1060a5df78ba4f22e3e9b151eebc2db61ed176d9021fba6648dL40-R42) [[4]](diffhunk://#diff-9554f533ae01d1060a5df78ba4f22e3e9b151eebc2db61ed176d9021fba6648dR119-R126)

**Tooling Upgrade:**

* Upgraded the JSON Schema validator in the HTML documentation from `ajv2019` to `ajv2020` to use a newer version and bundle. [[1]](diffhunk://#diff-9554f533ae01d1060a5df78ba4f22e3e9b151eebc2db61ed176d9021fba6648dL22-R26) [[2]](diffhunk://#diff-9ba8f2cc2f0585035429fc16880797043368609b25ae927fbdc909335ac8744bL16-R18)


Fixes #633 & #634 