### PR TITLE
fix: add endorsementJwt to the context with appropriate ID and container

### DIFF
--- a/ob_v3p0/context-3.0.3.json
+++ b/ob_v3p0/context-3.0.3.json
@@ -419,6 +419,10 @@
       "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#endorsement",
       "@container": "@set"
     },
+    "endorsementJwt": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#endorsementJwt",
+      "@container": "@set"
+    },
     "image": {
       "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#image",
       "@type": "@id"

--- a/ob_v3p0/errata/errata.md
+++ b/ob_v3p0/errata/errata.md
@@ -31,6 +31,7 @@ Previous versions of the context file will remain accessible, in order to keep b
 - `@id` of `achievement` in `AchievementSubject` now points to `https://purl.imsglobal.org/spec/vc/ob/vocab.html#achievement`
 - `@id` of `image` in `AchievementSubject` now points to `https://purl.imsglobal.org/spec/vc/ob/vocab.html#image`
 - `@id` of `image` in `Profile` now points to `https://purl.imsglobal.org/spec/vc/ob/vocab.html#image`
+- Added `endorsementJwt`.
 
 #### version 3.0.2
 

--- a/ob_v3p0/errata/ob_err_v3p0.html
+++ b/ob_v3p0/errata/ob_err_v3p0.html
@@ -37,9 +37,9 @@
                 specNature: 'informative', // spec nature is "normative" or "informative"
                 specType: 'errata', // spec type is "main", "cert", "impl", "errata" or other agreed upon string
                 specVersion: '3.0',
-                docVersion: '1.5',
+                docVersion: '1.6',
                 specStatus: "Final Release",
-                specDate: 'June 12, 2026',
+                specDate: 'June 29, 2026',
                 contributors: _contributors,
                 localBiblio: _localBiblio
             }
@@ -122,6 +122,14 @@
                         <td>June 12, 2026</td>
                         <td>
                             Added OpenAPI definition errors.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Version 3.0 Final</td>
+                        <td>1.6</td>
+                        <td>June 29, 2026</td>
+                        <td>
+                            Added `endorsementJwt` to JSON-LD context.
                         </td>
                     </tr>
                 </tbody>

--- a/ob_v3p0/microsites/v3p0.md
+++ b/ob_v3p0/microsites/v3p0.md
@@ -2588,6 +2588,10 @@ In this example, all required and optional properties are populated.
       "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#endorsement",
       "@container": "@set"
     },
+    "endorsementJwt": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#endorsementJwt",
+      "@container": "@set"
+    },
     "image": {
       "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#image",
       "@type": "@id"

--- a/ob_v3p0/microsites/v3p0.md
+++ b/ob_v3p0/microsites/v3p0.md
@@ -4,7 +4,7 @@ category: Specification
 title: Open Badges Specification
 shortcode: OB-30
 status: Final
-lastUpdated: 2026-06-15
+lastUpdated: 2026-06-29
 version: '3.0'
 nature: normative
 docType: specification
@@ -220,6 +220,10 @@ releases:
     docVersion: "1.4.4"
     date: 2026-06-15
     comments: "Fixed errors in OpenAPI files"
+  - version: "Final"
+    docVersion: "1.4.5"
+    date: 2026-06-29
+    comments: "Added <code>endorsementJwt</code> to JSON-LD context"
 resources:
   - standards/v3p0/spec/spec-resources.md
 ---

--- a/ob_v3p0/microsites/v3p0/errata.md
+++ b/ob_v3p0/microsites/v3p0/errata.md
@@ -131,6 +131,10 @@ releases:
     docVersion: 1.5
     date: 2026-06-12
     comments: Added OpenAPI definition errors.
+  - version: Version 3.0 Final
+    docVersion: 1.6
+    date: 2026-06-29
+    comments: Added `endorsementJwt` to JSON-LD context
 ---
 
 @standards/v3p0/errata/errata.md

--- a/ob_v3p0/microsites/v3p0/errata/errata.md
+++ b/ob_v3p0/microsites/v3p0/errata/errata.md
@@ -38,6 +38,7 @@ According to this policy, this section recaps all the changes made to the contex
 - `@id` of `achievement` in `AchievementSubject` now points to `https://purl.imsglobal.org/spec/vc/ob/vocab.html#achievement`
 - `@id` of `image` in `AchievementSubject` now points to `https://purl.imsglobal.org/spec/vc/ob/vocab.html#image`
 - `@id` of `image` in `Profile` now points to `https://purl.imsglobal.org/spec/vc/ob/vocab.html#image`
+- Added `endorsementJwt`.
 
 #### version 3.0.2
 

--- a/ob_v3p0/ob_v3p0.html
+++ b/ob_v3p0/ob_v3p0.html
@@ -27,9 +27,9 @@
       specNature: "normative", // spec nature is "normative" or "informative"
       specType: "main", // spec type is "main", "cert", "impl", "errata" or other agreed upon string
       specVersion: "3.0",
-      docVersion: "1.4.4",
+      docVersion: "1.4.5",
       specStatus: "Final Release",
-      specDate: "June 15, 2026",
+      specDate: "June 29, 2026",
       contributors: _contributors,
       localBiblio: _localBiblio,
       iprs: _iprs,
@@ -277,6 +277,16 @@
           <td>
             <ul>
                 <li>Fixed errors in OpenAPI files.</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>Final</td>
+          <td>1.4.5</td>
+          <td>June 29, 2026</td>
+          <td>
+            <ul>
+                <li>Added `endorsementJwt` to JSON-LD context.</li>
             </ul>
           </td>
         </tr>


### PR DESCRIPTION
This pull request introduces a new property definition to the `ob_v3p0/context-3.0.3.json` file, enhancing the data model for endorsements.

Schema updates:

* Added the `endorsementJwt` property to the context definition, mapping it to the appropriate IMS Global vocabulary URL and specifying its container as a set.